### PR TITLE
add a default bump in salary if the player is missing

### DIFF
--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -25,7 +25,6 @@ const playValues = {
 }
 
 const defaultSalary = 500000
-const defaultSalaryDelta = 100000
 
 let calcSalaries = function (stats: any, prevWeek: any) {
   let playerSalaries = {}
@@ -34,7 +33,7 @@ let calcSalaries = function (stats: any, prevWeek: any) {
     let salaryDelta = calcSalaryDelta(playerStats)
 
     if (salaryDelta === 0) {
-      salaryDelta = defaultSalaryDelta
+      salaryDelta = defaultSalaryDelta(playerName, prevWeek, stats)
     }
 
     let salary = previousSalary(prevWeek, playerName) + salaryDelta
@@ -57,6 +56,15 @@ let calcSalaryDelta = function (playerStats) {
   return _.sum(values)
 }
 
+let defaultSalaryDelta = function (playerName, prevWeek, stats) {
+  // player missed week 1. assign average salarayDelta
+  if (!prevWeek) return averageSalaryDelta(stats)
+
+  // use prevWeeks salary delta
+  let prevSalaryDelta = prevWeek.stats[playerName]['SalaryDelta']
+  if (prevSalaryDelta) return prevSalaryDelta
+}
+
 let previousSalary = function (prevWeek, playerName) {
   if (!prevWeek) return defaultSalary
 
@@ -64,6 +72,17 @@ let previousSalary = function (prevWeek, playerName) {
   if (!player) return defaultSalary
 
   return player['Salary']
+}
+
+let averageSalaryDelta = function (stats) {
+  let nonZeroDeltas = []
+
+  _.mapValues(stats, function (playerStats, playerName) {
+    let delta = calcSalaryDelta(playerStats)
+    if (delta !== 0) nonZeroDeltas.push(delta)
+  })
+
+  return _.sum(nonZeroDeltas) / nonZeroDeltas.length
 }
 
 module.exports = calcSalaries

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -61,8 +61,12 @@ let defaultSalaryDelta = function (playerName, prevWeek, stats) {
   if (!prevWeek) return averageSalaryDelta(stats)
 
   // use prevWeeks salary delta
-  let prevSalaryDelta = prevWeek.stats[playerName]['SalaryDelta']
+  let playerStats = prevWeek.stats[playerName] || {}
+  let prevSalaryDelta = playerStats['SalaryDelta']
   if (prevSalaryDelta) return prevSalaryDelta
+
+  // new player and its not week 1
+  return averageSalaryDelta(stats)
 }
 
 let previousSalary = function (prevWeek, playerName) {

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -32,8 +32,8 @@ let calcSalaries = function (stats: any, prevWeek: any) {
   _.mapValues(stats, function (playerStats, playerName) {
     let salaryDelta = calcSalaryDelta(playerStats)
 
-    if (salaryDelta === 0) {
-      salaryDelta = defaultSalaryDelta(playerName, prevWeek, stats)
+    if (_gameNotPlayed(salaryDelta)) {
+      salaryDelta = previousSalaryDelta(playerName, prevWeek, stats)
     }
 
     let salary = previousSalary(prevWeek, playerName) + salaryDelta
@@ -47,6 +47,10 @@ let calcSalaries = function (stats: any, prevWeek: any) {
   return playerSalaries
 }
 
+let _gameNotPlayed = function (salaryDelta) {
+  return salaryDelta === 0
+}
+
 let calcSalaryDelta = function (playerStats) {
   let values = _.mapValues(playValues, function (playValue, play) {
     let playCount = playerStats[play] || 0
@@ -56,7 +60,7 @@ let calcSalaryDelta = function (playerStats) {
   return _.sum(values)
 }
 
-let defaultSalaryDelta = function (playerName, prevWeek, stats) {
+let previousSalaryDelta = function (playerName, prevWeek, stats) {
   // player missed week 1. assign average salarayDelta
   if (!prevWeek) return averageSalaryDelta(stats)
 

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -65,7 +65,7 @@ let defaultSalaryDelta = function (playerName, prevWeek, stats) {
   let prevSalaryDelta = playerStats['SalaryDelta']
   if (prevSalaryDelta) return prevSalaryDelta
 
-  // new player and its not week 1
+  // new player and it is not week 1
   return averageSalaryDelta(stats)
 }
 
@@ -73,9 +73,20 @@ let previousSalary = function (prevWeek, playerName) {
   if (!prevWeek) return defaultSalary
 
   let player = prevWeek.stats[playerName]
-  if (!player) return defaultSalary
+  if (player) return player['Salary']
 
-  return player['Salary']
+  // new player and it is not week 1
+  return prevAverageSalaray(prevWeek)
+}
+
+let prevAverageSalaray = function (prevWeek) {
+  let nonZeroValues = []
+
+  _.mapValues(prevWeek.stats, function (playerStats, playerName) {
+    if (playerStats['Salary']) nonZeroValues.push(playerStats['Salary'])
+  })
+
+  return _.sum(nonZeroValues) / nonZeroValues.length
 }
 
 let averageSalaryDelta = function (stats) {

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -25,12 +25,18 @@ const playValues = {
 }
 
 const defaultSalary = 500000
+const defaultSalaryDelta = 100000
 
 let calcSalaries = function (stats: any, prevWeek: any) {
   let playerSalaries = {}
 
   _.mapValues(stats, function (playerStats, playerName) {
     let salaryDelta = calcSalaryDelta(playerStats)
+
+    if (salaryDelta === 0) {
+      salaryDelta = defaultSalaryDelta
+    }
+
     let salary = previousSalary(prevWeek, playerName) + salaryDelta
 
     playerSalaries[playerName] = {

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -61,7 +61,7 @@ let calcSalaryDelta = function (playerStats) {
 }
 
 let previousSalaryDelta = function (playerName, prevWeek, stats) {
-  // player missed week 1. assign average salarayDelta
+  // player missed week 1. assign average salaryDelta
   if (!prevWeek) return averageSalaryDelta(stats)
 
   // use prevWeeks salary delta
@@ -80,10 +80,10 @@ let previousSalary = function (prevWeek, playerName) {
   if (player) return player['Salary']
 
   // new player and it is not week 1
-  return prevAverageSalaray(prevWeek)
+  return prevAverageSalary(prevWeek)
 }
 
-let prevAverageSalaray = function (prevWeek) {
+let prevAverageSalary = function (prevWeek) {
   let nonZeroValues = []
 
   _.mapValues(prevWeek.stats, function (playerStats, playerName) {

--- a/lib/calc_week.js
+++ b/lib/calc_week.js
@@ -6,6 +6,8 @@ const Db = require('monk')(process.env.MONGODB_URI)
 const Games = Db.get('games')
 
 let calcWeek = async function (weekNum: number) {
+  if (weekNum === 0) return
+
   let docs = await fetchGames(weekNum)
   let stats = mergeGames({}, docs)
 

--- a/public/src/App.js
+++ b/public/src/App.js
@@ -30,7 +30,7 @@ class App extends Component {
 
   _fetchWeeks () {
     $.get('weeks', (weeks) => {
-      let week = _.last(weeks)
+      let week = _.last(weeks) || 0
       this.setState({ weeks: weeks, week: week, loading: false })
     })
   }

--- a/public/src/Stats.js
+++ b/public/src/Stats.js
@@ -6,9 +6,7 @@ import React, { Component } from 'react'
 import Griddle from 'griddle-react'
 import Loading from './Loading'
 
-const columns = [
-  'Name',
-  'Team',
+const STATS = [
   'Goals',
   'Assists',
   '2nd Assist',
@@ -18,6 +16,14 @@ const columns = [
   'Throwaways',
   'Drops',
   'Salary'
+]
+
+const zeroStats = _.zipObject(STATS)
+
+const columns = [
+  'Name',
+  'Team',
+  ...STATS
 ]
 
 type Props = {
@@ -69,12 +75,16 @@ export default class Stats extends Component {
     })
   }
 
+  _padStats (stats) {
+    return _.assign({}, zeroStats, stats)
+  }
+
   render () {
     if (this.state.loading) return (<Loading />)
 
     let stats = this.state.stats
     let statsArray = _.map(_.keys(stats), (k) => {
-      return { Name: k, ...stats[k] }
+      return { Name: k, ...this._padStats(stats[k]) }
     })
 
     return (

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -17,10 +17,15 @@ const Games = Db.get('games')
  */
 router.get('/stats', async function (req, res) {
   let games = await Games.find({}, {sort: {week: -1}})
-  let lastWeek = games[0].week
 
-  let stats = mergeGames({}, _.filter(games, (g) => g.week === lastWeek))
-  stats = addStats(stats, _.filter(games, (g) => g.week !== lastWeek))
+  let stats = {}
+
+  if (games.length > 0) {
+    let lastWeek = games[0].week
+
+    stats = mergeGames(stats, _.filter(games, (g) => g.week === lastWeek))
+    stats = addStats(stats, _.filter(games, (g) => g.week !== lastWeek))
+  }
 
   res.json({stats})
 })

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -36,7 +36,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 
-  it('gives previous weeks average salaray + gains to a new player in week 2 or higher', function () {
+  it('gives previous weeks average salary + gains to a new player in week 2 or higher', function () {
     let stats = {
       'Mike': {'Team': 'Beans', 'Goals': 2},
       'Jill': {'Team': 'Beans', 'Goals': 1}
@@ -52,7 +52,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(120000)
   })
 
-  it('gives previous weeks average salaray to a new absent player in week 2 or higher', function () {
+  it('gives previous weeks average salary to a new absent player in week 2 or higher', function () {
     let stats = {
       'Mike': {'Team': 'Beans'},
       'Jill': {'Team': 'Beans', 'Goals': 1}
@@ -68,7 +68,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(110000)
   })
 
-  it('gives the average salaray delta to a player who misses week 1', function () {
+  it('gives the average salary delta to a player who misses week 1', function () {
     let stats = {
       'Mike': {'Team': 'Beans'},
       'Jim': {'Team': 'Beans', 'Goals': 1},
@@ -86,7 +86,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(expectedSalary)
   })
 
-  it('gives salaray delta from the previous week if player is absent', function () {
+  it('gives salary delta from the previous week if player is absent', function () {
     let stats = {
       'Mike': {'Team': 'Beans'}
     }

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -26,7 +26,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(-5000)
   })
 
-  it('sets default for initial salary', function () {
+  it('gives the default for initial salary', function () {
     let stats = {
       'Mike': {
         'Drops': 1
@@ -34,6 +34,22 @@ describe('calcSalaries', function () {
     }
     let salaryDeltas = calcSalaries(stats)
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
+  })
+
+  it('gives default salaray to a new player in week 2 or higher', function () {
+    let stats = {
+      'Mike': {'Team': 'Beans'},
+      'Jill': {'Team': 'Beans', 'Goals': 1}
+    }
+
+    let prevWeek = {
+      week: 2,
+      stats: {'Jill': {'SalaryDelta': 11000}}
+    }
+
+    let salaryDeltas = calcSalaries(stats, prevWeek)
+    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(10000)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(510000)
   })
 
   it('gives the average salaray delta to a player who misses week 1', function () {

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -36,6 +36,15 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 
+  it('sets default if missing', function () {
+    let stats = {
+      'Mike': {'Team': 'Beans'}
+    }
+    let salaryDeltas = calcSalaries(stats)
+    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(100000)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(600000)
+  })
+
   it('adds to previous salary', function () {
     let stats = {
       'Mike': {

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -36,7 +36,23 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 
-  it('gives default salaray to a new player in week 2 or higher', function () {
+  it('gives previous weeks average salaray + gains to a new player in week 2 or higher', function () {
+    let stats = {
+      'Mike': {'Team': 'Beans', 'Goals': 2},
+      'Jill': {'Team': 'Beans', 'Goals': 1}
+    }
+
+    let prevWeek = {
+      week: 2,
+      stats: {'Jill': {'Salary': 100000, 'SalaryDelta': 5000}}
+    }
+
+    let salaryDeltas = calcSalaries(stats, prevWeek)
+    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(20000)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(120000)
+  })
+
+  it('gives previous weeks average salaray to a new absent player in week 2 or higher', function () {
     let stats = {
       'Mike': {'Team': 'Beans'},
       'Jill': {'Team': 'Beans', 'Goals': 1}
@@ -44,12 +60,12 @@ describe('calcSalaries', function () {
 
     let prevWeek = {
       week: 2,
-      stats: {'Jill': {'SalaryDelta': 11000}}
+      stats: {'Jill': {'Salary': 100000, 'SalaryDelta': 5000}}
     }
 
     let salaryDeltas = calcSalaries(stats, prevWeek)
     expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(10000)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(510000)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(110000)
   })
 
   it('gives the average salaray delta to a player who misses week 1', function () {

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -36,13 +36,39 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 
-  it('sets default if missing', function () {
+  it('gives the average salaray delta to a player who misses week 1', function () {
+    let stats = {
+      'Mike': {'Team': 'Beans'},
+      'Jim': {'Team': 'Beans', 'Goals': 1},
+      'Meg': {'Team': 'Beans', 'D-Blocks': 1}
+    }
+
+    // 1 playValues[Goal] * 1 playValues[D-Block]
+    let expectedDelta = (10000 + 8000) / 2
+
+    // defaultSalary + expectedDelta
+    let expectedSalary = 500000 + expectedDelta
+
+    let salaryDeltas = calcSalaries(stats)
+    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(expectedDelta)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(expectedSalary)
+  })
+
+  it('gives salaray delta from the previous week if player is absent', function () {
     let stats = {
       'Mike': {'Team': 'Beans'}
     }
-    let salaryDeltas = calcSalaries(stats)
-    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(100000)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(600000)
+
+    let prevWeek = {
+      week: 1,
+      stats: {
+        'Mike': {'Team': 'Beans', 'Goals': 1, 'SalaryDelta': 10000, 'Salary': 500000}
+      }
+    }
+
+    let salaryDeltas = calcSalaries(stats, prevWeek)
+    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(10000)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(510000)
   })
 
   it('adds to previous salary', function () {

--- a/test/routes/stats_test.js
+++ b/test/routes/stats_test.js
@@ -16,7 +16,7 @@ describe('stats route', function () {
   var game1 = {
     week: 1,
     stats: {
-      'Mike': { 'Goals': 1, 'Salaray': 1000 }
+      'Mike': { 'Goals': 1, 'Salary': 1000 }
     }
   }
 


### PR DESCRIPTION
for #17 

* Gives players missing in week 1 the league average
* Gives players missing in later weeks their last salary (note that if you think about it this means I am always covered. Since a player always has a salary from the Prev week. actually this isn't true if they are added to the league ...)

Notes:
* A player is missing if their salaryDelta is 0. It's possible this gets triggered for someone who has a really poor game. 
  * this could be fixed by giving a small salary increase for number of points played / if a point was played.