### PR TITLE
calculate week rather than saving it

### DIFF
--- a/lib/calc_week.js
+++ b/lib/calc_week.js
@@ -1,0 +1,27 @@
+// @flow
+
+import _ from 'lodash'
+
+const db = require('monk')(process.env.MONGODB_URI)
+const games = db.get('games')
+
+let calcWeek = async function (weekNum: number) {
+  let stats = {}
+
+  let docs = await fetchGames(weekNum)
+  _.each(docs, (g) => {
+    _.merge(stats, g.stats)
+  })
+
+  return {
+    week: weekNum,
+    stats: stats
+  }
+}
+
+let fetchGames = async function (weekNum) {
+  let docs = await games.find({week: weekNum}, {})
+  return docs
+}
+
+module.exports = calcWeek

--- a/public/src/App.js
+++ b/public/src/App.js
@@ -1,20 +1,38 @@
 // @flow
 
+import $ from 'jquery'
+import _ from 'lodash'
 import React, { Component } from 'react'
 import Nav from './Nav'
 import Stats from './Stats'
+import Loading from './Loading'
 
 class App extends Component {
   state: {
-    week: number
+    loading: boolean,
+    weeks: any,
+    week: number,
   }
 
   constructor (props: any) {
     super(props)
 
     this.state = {
-      week: 1
+      loading: true,
+      weeks: [],
+      week: 0
     }
+  }
+
+  componentWillMount () {
+    this._fetchWeeks()
+  }
+
+  _fetchWeeks () {
+    $.get('weeks', (weeks) => {
+      let week = _.last(weeks)
+      this.setState({ weeks: weeks, week: week, loading: false })
+    })
   }
 
   weekChange (week: number) {
@@ -22,8 +40,10 @@ class App extends Component {
   }
 
   render () {
+    if (this.state.loading) return (<Loading />)
+
     let week = this.state.week
-    let weeks = [1, 2]
+    let weeks = this.state.weeks
 
     let weekChange = this.weekChange.bind(this)
 

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -5,12 +5,12 @@ let router = express.Router()
 
 const db = require('monk')(process.env.MONGODB_URI)
 const games = db.get('games')
-const weeks = db.get('weeks')
 
 import _ from 'lodash'
 import calcStats from '../lib/calc_stats'
 import calcSalaries from '../lib/calc_salaries'
 import calcTeams from '../lib/calc_teams'
+import calcWeek from '../lib/calc_week'
 
 /**
  * @api {post} /upload Upload Game Events
@@ -25,7 +25,7 @@ router.post('/upload', async function (req, res) {
   let game = { ...req.body, time: new Date() }
 
   let prevWeekNum = game.week - 1
-  let prevWeek = await findWeek(prevWeekNum)
+  let prevWeek = await calcWeek(prevWeekNum)
 
   await createGame(game)
 
@@ -39,7 +39,6 @@ router.post('/upload', async function (req, res) {
   game.stats = _.merge(game.stats, salaries)
 
   await saveGame(game)
-  await updateWeek(game.week, game.stats)
 
   res.status(201).send(game)
 })
@@ -48,33 +47,10 @@ let createGame = function (game) {
   return games.insert(game)
 }
 
-let findWeek = function (weekNum) {
-  return weeks.findOne({week: weekNum})
-}
-
 let saveGame = function (game) {
   return games.update(
     {_id: game._id},
     {$set: {stats: game.stats}},
-  )
-}
-
-let updateWeek = async function (weekNum, gameStats) {
-  let week = await findWeek(weekNum)
-  let weekStats = week ? week.stats : {}
-  let stats = _.assign({}, weekStats, gameStats)
-
-  return saveWeek(weekNum, stats)
-}
-
-let saveWeek = function (week, stats) {
-  weeks.update(
-    {week: week},
-    {
-      $set: {stats: stats},
-      $setOnInsert: {week: week}
-    },
-    {upsert: true}
   )
 }
 

--- a/routes/weeks.js
+++ b/routes/weeks.js
@@ -4,7 +4,9 @@ import express from 'express'
 let router = express.Router()
 
 const db = require('monk')(process.env.MONGODB_URI)
-const weeks = db.get('weeks')
+const games = db.get('games')
+
+import calcWeek from '../lib/calc_week'
 
 /**
  * @api {get} /weeks List of weeks
@@ -14,8 +16,8 @@ const weeks = db.get('weeks')
  * @apiSuccess (200)
  */
 router.get('/weeks', async function (req, res) {
-  let docs = await weeks.find({}, {})
-  res.json(docs)
+  let weeks = await games.distinct('week')
+  res.json(weeks)
 })
 
 /**
@@ -26,8 +28,9 @@ router.get('/weeks', async function (req, res) {
  * @apiSuccess (200)
  */
 router.get('/weeks/:week', async function (req, res) {
-  let doc = await weeks.findOne({week: parseInt(req.params.week)})
-  res.json(doc)
+  let weekNum = parseInt(req.params.week)
+  let week = await calcWeek(weekNum)
+  res.json(week)
 })
 
 module.exports = router

--- a/test/routes/games_test.js
+++ b/test/routes/games_test.js
@@ -2,7 +2,6 @@ import chai from 'chai'
 let expect = chai.expect
 
 chai.use(require('sinon-chai'))
-import sinon from 'mocha-sinon'
 import request from 'request-promise'
 
 process.env.TEST = 1

--- a/test/routes/upload_test.js
+++ b/test/routes/upload_test.js
@@ -3,14 +3,12 @@ import chai from 'chai'
 let expect = chai.expect
 
 chai.use(require('sinon-chai'))
-import sinon from 'mocha-sinon'
 import request from 'request-promise'
 
 process.env.TEST = 1
 process.env.MONGODB_URI = 'mongodb://localhost:27017/test'
 const db = require('monk')(process.env.MONGODB_URI)
 const games = db.get('games')
-const weeks = db.get('weeks')
 
 describe('POST /upload', function () {
   var server = require('../../server')
@@ -63,9 +61,8 @@ describe('POST /upload', function () {
     server.listen(3001)
   })
 
-  afterEach(function (){
+  afterEach(function () {
     games.drop()
-    weeks.drop()
   })
 
   after(function () {
@@ -128,47 +125,15 @@ describe('POST /upload', function () {
     expect(stats['Jill']['Drops']).to.equal(1)
   })
 
-  it("saves a new week to mongodb if week doesn't exist yet", async function () {
-    await request.post({url: url, json: true, body: game1})
-
-    let week = await weeks.findOne()
-    let stats = week.stats
-
-    expect(_.keys(stats).length).to.equal(4)
-    expect(stats['Mike']['Pulls']).to.equal(1)
-    expect(stats['Mike']['Goals']).to.equal(1)
-    expect(stats['Jill']['Drops']).to.equal(1)
-  })
-
-  it('updates the week in mongodb if week exists', async function () {
-    await request.post({url: url, json: true, body: game1})
-    await request.post({url: url, json: true, body: game2})
-
-    let week = await weeks.findOne()
-    let stats = week.stats
-
-    expect(_.keys(stats).length).to.equal(8)
-
-    // from game1
-    expect(stats['Mike']['Pulls']).to.equal(1)
-    expect(stats['Mike']['Goals']).to.equal(1)
-    expect(stats['Jill']['Drops']).to.equal(1)
-
-    // from game2
-    expect(stats['Joe']['Pulls']).to.equal(1)
-    expect(stats['Joe']['Goals']).to.equal(1)
-    expect(stats['Meg']['Drops']).to.equal(1)
-  })
-
   it('salary adds week to week', async function () {
     await request.post({url: url, json: true, body: game1})
     game1.week = 2
     await request.post({url: url, json: true, body: game1})
 
-    let week1 = await weeks.findOne({week: 1})
-    let week2 = await weeks.findOne({week: 2})
+    let g1 = await games.findOne({week: 1})
+    let g2 = await games.findOne({week: 2})
 
-    expect(week1.stats['Mike']['Salary']).to.equal(511000)
-    expect(week2.stats['Mike']['Salary']).to.equal(522000)
+    expect(g1.stats['Mike']['Salary']).to.equal(511000)
+    expect(g2.stats['Mike']['Salary']).to.equal(522000)
   })
 })

--- a/test/routes/weeks_test.js
+++ b/test/routes/weeks_test.js
@@ -1,45 +1,54 @@
+import _ from 'lodash'
 import chai from 'chai'
 let expect = chai.expect
 
 chai.use(require('sinon-chai'))
-import sinon from 'mocha-sinon'
 import request from 'request-promise'
 
 process.env.TEST = 1
 process.env.MONGODB_URI = 'mongodb://localhost:27017/test'
 const db = require('monk')(process.env.MONGODB_URI)
-const weeks = db.get('weeks')
+const games = db.get('games')
 
 describe('weeks routes', function () {
   var server = require('../../server')
 
-  var week = {
+  var game1 = {
     week: 1,
     stats: {
       'Mike': { 'Goals': 1 }
     }
   }
 
+  var game2 = {
+    week: 1,
+    stats: {
+      'Bill': { 'Goals': 1 }
+    }
+  }
+
+  var stats = _.assign({}, game1.stats, game2.stats)
+
   before(async function () {
     server.listen(3001)
-    await weeks.insert(week)
+    await games.insert(game1)
+    await games.insert(game2)
   })
 
   after(function () {
-    weeks.drop()
+    games.drop()
     server.close()
   })
 
   describe('GET /weeks', function () {
     var url = 'http://localhost:3001/weeks'
 
-    it('returns a list of weeks', async function () {
+    it('returns a list of week numbers', async function () {
       let response = await request.get({url: url, resolveWithFullResponse: true})
       let body = JSON.parse(response.body)
 
       expect(response.statusCode).to.equal(200)
-      expect(body[0].week).to.equal(week.week)
-      expect(body[0].stats).to.deep.equal(week.stats)
+      expect(body).to.deep.equal([1])
     })
   })
 
@@ -47,13 +56,13 @@ describe('weeks routes', function () {
     var url = 'http://localhost:3001/weeks/'
 
     it('returns a week', async function () {
-      url = url + week.week
+      url = url + game1.week
       let response = await request.get({url: url, resolveWithFullResponse: true})
       let body = JSON.parse(response.body)
 
       expect(response.statusCode).to.equal(200)
-      expect(body.week).to.equal(week.week)
-      expect(body.stats).to.deep.equal(week.stats)
+      expect(body.week).to.equal(game1.week)
+      expect(body.stats).to.deep.equal(stats)
     })
   })
 })


### PR DESCRIPTION
This PR changes the server to calculate the week object rather than saving it. The reasons for this is simplicity. Denormalizing the stats data to a week document means that if the game needs to be changed (#18) so does the week. 

The calculation just fetches all the games and merges the stats from each. This is pretty quick too and I have no reason to think it would ever be too slow.

I also changed the `weeks` index endpoint to just return an array of week numbers. There was no need for the proper index. Then I pulled this data into the UI closes #29.

closes #18  