### PR TITLE
calc week fallback

### DIFF
--- a/lib/calc_week_num.js
+++ b/lib/calc_week_num.js
@@ -1,0 +1,29 @@
+// @flow
+
+const GAME_DATES = [
+  '2016-11-07',
+  '2016-11-14',
+  '2016-11-21',
+  '2016-11-28',
+  '2016-12-05',
+  '2016-12-12',
+  '2016-12-19',
+  '2017-01-09',
+  '2017-01-16'
+]
+
+let calcWeekNum = function (date: Date) {
+  let weekNum = 0
+
+  for (let gameDate of GAME_DATES) {
+    if (pastWeek(date, gameDate)) { weekNum = weekNum + 1 }
+  }
+
+  return weekNum
+}
+
+let pastWeek = function (date, gameDate) {
+  return date >= new Date(gameDate)
+}
+
+module.exports = calcWeekNum

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -11,6 +11,7 @@ import calcStats from '../lib/calc_stats'
 import calcSalaries from '../lib/calc_salaries'
 import calcTeams from '../lib/calc_teams'
 import calcWeek from '../lib/calc_week'
+import calcWeekNum from '../lib/calc_week_num'
 
 /**
  * @api {post} /upload From Stats Keeper Client
@@ -38,7 +39,9 @@ import calcWeek from '../lib/calc_week'
  *     }
  */
 router.post('/upload', async function (req, res) {
-  let game = { ...req.body, time: new Date() }
+  let game = {...req.body, time: new Date()}
+  game.week = game.week || calcWeekNum(new Date())
+
   await createGame(game)
 
   let prevWeekNum = game.week - 1

--- a/test/lib/calc_week_num_test.js
+++ b/test/lib/calc_week_num_test.js
@@ -1,0 +1,18 @@
+import chai from 'chai'
+let expect = chai.expect
+
+import calcWeekNum from '../../lib/calc_week_num'
+
+describe('calcWeekNum', function () {
+  it('returns week 1 for a date less than week 2', function () {
+    let date = new Date('2016-11-07')
+    let week = calcWeekNum(date)
+    expect(week).to.equal(1)
+  })
+
+  it('returns week 2 for a date less than week 3 but greater than week 2', function () {
+    let date = new Date('2016-11-19')
+    let week = calcWeekNum(date)
+    expect(week).to.equal(2)
+  })
+})


### PR DESCRIPTION
server side bit for https://github.com/kevinhughes27/parity-client/issues/12

I left it as a fallback since otherwise it makes all the other tests shittier to work with since you'd have to stub Date.now() which will suck.

Eventually I still want the client telling the server what week the stats are for. 