### PR TITLE
fix on field stats

### DIFF
--- a/lib/calc_stats.js
+++ b/lib/calc_stats.js
@@ -121,14 +121,17 @@ function groupEvents (events) {
   let endOfDirectionEvents = []
   let passingEvents = []
   let onFieldEvents = []
+  let directionIsLeft
 
   events.forEach(function (e) {
     e = prepareEvent(e)
 
-    if (isSwitchingDirectionEvent(e[0])) {
+    if (e[0] === 'Direction') {
+      directionIsLeft = isLeft(e[1])
+    } else if (isSwitchingDirectionEvent(e[0])) {
       switchingDirectionEvents.push(e)
     } else if (isEndOfDirectionEvent(e[0])) {
-      endOfDirectionEvents.push(e.slice(0, 2))
+      endOfDirectionEvents.push([e[0], e[1], directionIsLeft])
       passingEvents.push(e.slice(2, e.length))
     } else if (isOnFieldEvent(e[0])) {
       onFieldEvents.push(e)
@@ -139,7 +142,7 @@ function groupEvents (events) {
   let numPoints = pointEvents.length
   let numPlayersOnField = onFieldEvents.length / numPoints
 
-  endOfDirectionEvents.forEach(function (e, i) {
+  pointEvents.forEach(function (e, i) {
     let offset = numPlayersOnField
     let start = i * offset
     let middle = i * offset + offset / 2
@@ -148,12 +151,19 @@ function groupEvents (events) {
     let OffenseOnFieldEvents = _.slice(onFieldEvents.slice(start, middle))
     let DefenseOnFieldEvents = _.slice(onFieldEvents.slice(middle, end))
 
+    // directionIsLeft
+    if (e[2]) {
+      let tmp = OffenseOnFieldEvents
+      OffenseOnFieldEvents = DefenseOnFieldEvents
+      DefenseOnFieldEvents = tmp
+    }
+
     OffenseOnFieldEvents.forEach(function (e) {
-      e[0] === '1' ? e[0] = 'O+' : e[0] = 'O-'
+      e[0] === '+1' ? e[0] = 'O+' : e[0] = 'O-'
     })
 
     DefenseOnFieldEvents.forEach(function (e) {
-      e[0] === '1' ? e[0] = 'D+' : e[0] = 'D-'
+      e[0] === '+1' ? e[0] = 'D+' : e[0] = 'D-'
     })
   })
 
@@ -163,6 +173,10 @@ function groupEvents (events) {
     passingEvents: passingEvents,
     onFieldEvents: onFieldEvents
   }
+}
+
+function isLeft (token) {
+  return token === '<<<<<<'
 }
 
 function isSwitchingDirectionEvent (token) {
@@ -177,7 +191,7 @@ function isEndOfDirectionEvent (token) {
 }
 
 function isOnFieldEvent (token) {
-  return token === '1' ||
+  return token === '+1' ||
          token === '-1'
 }
 

--- a/test/lib/calc_stats_test.js
+++ b/test/lib/calc_stats_test.js
@@ -115,7 +115,7 @@ describe('calcStats', function () {
   it('stat: OPointsFor', function () {
     let input = [
       'POINT,Jill',
-      '1,Jill',
+      '+1,Jill',
       '-1,Jane'
     ]
 
@@ -123,10 +123,22 @@ describe('calcStats', function () {
     expect(output['Jill']['OPointsFor']).to.equal(1)
   })
 
+  it('stat: OPointsFor with direction swap', function () {
+    let input = [
+      'Direction,<<<<<<',
+      'POINT,Jill',
+      '+1,Jill',
+      '-1,Jane'
+    ]
+
+    let output = calcStats(input)
+    expect(output['Jill']['DPointsFor']).to.equal(1)
+  })
+
   it('stat: DPointsAgainst', function () {
     let input = [
       'POINT,Jill',
-      '1,Jill',
+      '+1,Jill',
       '-1,Jane'
     ]
 
@@ -140,8 +152,8 @@ describe('calcStats', function () {
       'POINT,Mike,Pass,Jane',
       '-1,Jill',
       '-1,Bob',
-      '1,Mike',
-      '1,Jane'
+      '+1,Mike',
+      '+1,Jane'
     ]
 
     let output = calcStats(input)
@@ -155,8 +167,8 @@ describe('calcStats', function () {
       'POINT,Mike,Pass,Jane',
       '-1,Jill',
       '-1,Bob',
-      '1,Mike',
-      '1,Jane'
+      '+1,Mike',
+      '+1,Jane'
     ]
 
     let output = calcStats(input)
@@ -171,11 +183,11 @@ describe('calcStats', function () {
       'POINT,Mike,Pass,Jane',
       '-1,Jill',
       '-1,Bob',
-      '1,Mike',
-      '1,Jane',
+      '+1,Mike',
+      '+1,Jane',
       'POINT,Jill,Pass,Bob,Jill',
-      '1,Jill',
-      '1,Bob',
+      '+1,Jill',
+      '+1,Bob',
       '-1,Mike',
       '-1,Jane',
       'Throw Away,Jane'


### PR DESCRIPTION
When I ported the code to handle the raw output from android (not the same data you can see in previous years spreadsheets) I mistakenly assumed that the players were written out as Offense first then Defense. This was actually done in another script in between.

This PR fixes that error for now until we move to out new model where this is explicit. I will re-upload the data to production after testing locally with this.