### PR TITLE
fix old stats parse OPointsFor etc

### DIFF
--- a/lib/calc_stats.js
+++ b/lib/calc_stats.js
@@ -121,20 +121,30 @@ function groupEvents (events) {
   let endOfDirectionEvents = []
   let passingEvents = []
   let onFieldEvents = []
-  let directionIsLeft
 
-  events.forEach(function (e) {
+  let isDirectionLeft
+  let isLastPointLeft
+
+  events.forEach(function (e, idx) {
     e = prepareEvent(e)
 
-    if (e[0] === 'Direction') {
-      directionIsLeft = isLeft(e[1])
-    } else if (isSwitchingDirectionEvent(e[0])) {
+    if (e[0] === 'Pull') {
+      switchingDirectionEvents.push(e)
+      let nextEv = prepareEvent(events[idx + 1])
+      isLastPointLeft = isLeft(nextEv[1])
+    } else if (e[0] === 'D') {
       switchingDirectionEvents.push(e)
     } else if (isEndOfDirectionEvent(e[0])) {
-      endOfDirectionEvents.push([e[0], e[1], directionIsLeft])
+      endOfDirectionEvents.push(e.slice(0, 2))
       passingEvents.push(e.slice(2, e.length))
+    } else if (e[0] === 'POINT') {
+      endOfDirectionEvents.push([e[0], e[1], isLastPointLeft])
+      passingEvents.push(e.slice(2, e.length))
+      isLastPointLeft = !isDirectionLeft
     } else if (isOnFieldEvent(e[0])) {
       onFieldEvents.push(e)
+    } else if (e[0] === 'Direction') {
+      isDirectionLeft = isLeft(e[1])
     }
   })
 
@@ -148,22 +158,25 @@ function groupEvents (events) {
     let middle = i * offset + offset / 2
     let end = i * offset + offset
 
-    let OffenseOnFieldEvents = _.slice(onFieldEvents.slice(start, middle))
-    let DefenseOnFieldEvents = _.slice(onFieldEvents.slice(middle, end))
+    let leftTeam = _.slice(onFieldEvents.slice(start, middle))
+    let rightTeam = _.slice(onFieldEvents.slice(middle, end))
 
-    // directionIsLeft
-    if (e[2]) {
-      let tmp = OffenseOnFieldEvents
-      OffenseOnFieldEvents = DefenseOnFieldEvents
-      DefenseOnFieldEvents = tmp
-    }
+    let isLastPointLeft = e[2]
 
-    OffenseOnFieldEvents.forEach(function (e) {
-      e[0] === '+1' ? e[0] = 'O+' : e[0] = 'O-'
+    leftTeam.forEach(function (e) {
+      if (isLastPointLeft) {
+        e[0] = 'O' + e[0][0]
+      } else {
+        e[0] = 'D' + e[0][0]
+      }
     })
 
-    DefenseOnFieldEvents.forEach(function (e) {
-      e[0] === '+1' ? e[0] = 'D+' : e[0] = 'D-'
+    rightTeam.forEach(function (e) {
+      if (isLastPointLeft) {
+        e[0] = 'D' + e[0][0]
+      } else {
+        e[0] = 'O' + e[0][0]
+      }
     })
   })
 
@@ -176,17 +189,11 @@ function groupEvents (events) {
 }
 
 function isLeft (token) {
-  return token === '<<<<<<'
-}
-
-function isSwitchingDirectionEvent (token) {
-  return token === 'Pull' ||
-         token === 'D'
+  return token === '>>>>>>'
 }
 
 function isEndOfDirectionEvent (token) {
-  return token === 'POINT' ||
-         token === 'Drop' ||
+  return token === 'Drop' ||
          token === 'Throw Away'
 }
 

--- a/test/lib/calc_stats_test.js
+++ b/test/lib/calc_stats_test.js
@@ -112,10 +112,14 @@ describe('calcStats', function () {
     expect(output['Jill']['Calihan']).to.equal(1)
   })
 
-  it('stat: OPointsFor', function () {
+  it('stat: OPointsFor (direction left)', function () {
     let input = [
-      'POINT,Jill',
+      'Pull,Mike',
+      'Direction,>>>>>>',
+      'POINT,Jill,Pass,Bob',
       '+1,Jill',
+      '+1,Bob',
+      '-1,Mike',
       '-1,Jane'
     ]
 
@@ -123,22 +127,29 @@ describe('calcStats', function () {
     expect(output['Jill']['OPointsFor']).to.equal(1)
   })
 
-  it('stat: OPointsFor with direction swap', function () {
+  it('stat: OPointsFor (direction not left)', function () {
     let input = [
+      'Pull,Jill',
       'Direction,<<<<<<',
-      'POINT,Jill',
-      '+1,Jill',
-      '-1,Jane'
+      'POINT,Jane,Pass,Mike',
+      '-1,Jill',
+      '-1,Bob',
+      '+1,Mike',
+      '+1,Jane'
     ]
 
     let output = calcStats(input)
-    expect(output['Jill']['DPointsFor']).to.equal(1)
+    expect(output['Jane']['OPointsFor']).to.equal(1)
   })
 
-  it('stat: DPointsAgainst', function () {
+  it('stat: DPointsAgainst (direction left)', function () {
     let input = [
-      'POINT,Jill',
+      'Pull,Mike',
+      'Direction,>>>>>>',
+      'POINT,Jill,Pass,Bob',
       '+1,Jill',
+      '+1,Bob',
+      '-1,Mike',
       '-1,Jane'
     ]
 
@@ -146,9 +157,27 @@ describe('calcStats', function () {
     expect(output['Jane']['DPointsAgainst']).to.equal(1)
   })
 
-  it('stat: OPointsAgainst', function () {
+  it('stat: DPointsAgainst (direction not left)', function () {
     let input = [
+      'Pull,Jill',
+      'Direction,<<<<<<',
+      'POINT,Jane,Pass,Mike',
+      '-1,Jill',
+      '-1,Bob',
+      '+1,Mike',
+      '+1,Jane'
+    ]
+
+    let output = calcStats(input)
+    expect(output['Jill']['DPointsAgainst']).to.equal(1)
+  })
+
+  it('stat: OPointsAgainst (direction left)', function () {
+    let input = [
+      'Pull,Mike',
+      'Direction,>>>>>>',
       'Drop,Jill,Pass,Bob',
+      'Direction,<<<<<<',
       'POINT,Mike,Pass,Jane',
       '-1,Jill',
       '-1,Bob',
@@ -161,9 +190,30 @@ describe('calcStats', function () {
     expect(output['Jill']['OPointsAgainst']).to.equal(1)
   })
 
-  it('stat: DPointsFor', function () {
+  it('stat: OPointsAgainst (direction not left)', function () {
     let input = [
+      'Pull,Jill',
+      'Direction,<<<<<<',
+      'Drop,Mike,Pass,Jane',
+      'Direction,>>>>>>',
+      'POINT,Jill,Pass,Bob',
+      '+1,Jill',
+      '+1,Bob',
+      '-1,Mike',
+      '-1,Jane'
+    ]
+
+    let output = calcStats(input)
+    expect(output['Mike']['OPointsAgainst']).to.equal(1)
+    expect(output['Jane']['OPointsAgainst']).to.equal(1)
+  })
+
+  it('stat: DPointsFor (direction left)', function () {
+    let input = [
+      'Pull,Mike',
+      'Direction,>>>>>>',
       'Drop,Jill,Pass,Bob',
+      'Direction,<<<<<<',
       'POINT,Mike,Pass,Jane',
       '-1,Jill',
       '-1,Bob',
@@ -176,20 +226,42 @@ describe('calcStats', function () {
     expect(output['Mike']['DPointsFor']).to.equal(1)
   })
 
+  it('stat: DPointsFor (direction not left)', function () {
+    let input = [
+      'Pull,Jill',
+      'Direction,<<<<<<',
+      'Drop,Mike,Pass,Jane',
+      'Direction,>>>>>>',
+      'POINT,Jill,Pass,Bob',
+      '+1,Jill',
+      '+1,Bob',
+      '-1,Mike',
+      '-1,Jane'
+    ]
+
+    let output = calcStats(input)
+    expect(output['Jill']['DPointsFor']).to.equal(1)
+    expect(output['Bob']['DPointsFor']).to.equal(1)
+  })
+
   it('test game A', function () {
     let input = [
       'Pull,Mike',
+      'Direction,>>>>>>',
       'Drop,Jill,Pass,Bob',
+      'Direction,<<<<<<',
       'POINT,Mike,Pass,Jane',
       '-1,Jill',
       '-1,Bob',
       '+1,Mike',
       '+1,Jane',
-      'POINT,Jill,Pass,Bob,Jill',
+      'Direction,>>>>>>',
+      'POINT,Jill,Pass,Bob',
       '+1,Jill',
       '+1,Bob',
       '-1,Mike',
       '-1,Jane',
+      'Direction,<<<<<<',
       'Throw Away,Jane'
     ]
 


### PR DESCRIPTION
actually fixes the issues with Points for and against. Its quiet complex because of how the data is stored. The Left team (of the tablet UI) is always written first so it needs to be determined if they were on offense or not. This state is initialised by detecting a `Pull` event and then keeping track of the direction as points are scored. This is and will be much simpler in our new model.