### PR TITLE
use team average salary for absent player

### DIFF
--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -33,7 +33,7 @@ let calcSalaries = function (stats: any, prevWeek: any) {
     let salaryDelta = calcSalaryDelta(playerStats)
 
     if (_gameNotPlayed(salaryDelta)) {
-      salaryDelta = previousSalaryDelta(playerName, prevWeek, stats)
+      salaryDelta = averageSalaryDelta(stats, playerStats['Team'])
     }
 
     let salary = previousSalary(prevWeek, playerName) + salaryDelta
@@ -60,19 +60,6 @@ let calcSalaryDelta = function (playerStats) {
   return _.sum(values)
 }
 
-let previousSalaryDelta = function (playerName, prevWeek, stats) {
-  // player missed week 1. assign average salaryDelta
-  if (!prevWeek) return averageSalaryDelta(stats)
-
-  // use prevWeeks salary delta
-  let playerStats = prevWeek.stats[playerName] || {}
-  let prevSalaryDelta = playerStats['SalaryDelta']
-  if (prevSalaryDelta) return prevSalaryDelta
-
-  // new player and it is not week 1
-  return averageSalaryDelta(stats)
-}
-
 let previousSalary = function (prevWeek, playerName) {
   if (!prevWeek) return defaultSalary
 
@@ -93,10 +80,12 @@ let prevAverageSalary = function (prevWeek) {
   return _.sum(nonZeroValues) / nonZeroValues.length
 }
 
-let averageSalaryDelta = function (stats) {
+let averageSalaryDelta = function (stats, team) {
+  let teamStats = _.filter(stats, (s) => s['Team'] === team)
+
   let nonZeroDeltas = []
 
-  _.mapValues(stats, function (playerStats, playerName) {
+  _.mapValues(teamStats, function (playerStats, playerName) {
     let delta = calcSalaryDelta(playerStats)
     if (delta !== 0) nonZeroDeltas.push(delta)
   })

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -36,39 +36,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 
-  it('gives previous weeks average salary + gains to a new player in week 2 or higher', function () {
-    let stats = {
-      'Mike': {'Team': 'Beans', 'Goals': 2},
-      'Jill': {'Team': 'Beans', 'Goals': 1}
-    }
-
-    let prevWeek = {
-      week: 2,
-      stats: {'Jill': {'Salary': 100000, 'SalaryDelta': 5000}}
-    }
-
-    let salaryDeltas = calcSalaries(stats, prevWeek)
-    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(20000)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(120000)
-  })
-
-  it('gives previous weeks average salary to a new absent player in week 2 or higher', function () {
-    let stats = {
-      'Mike': {'Team': 'Beans'},
-      'Jill': {'Team': 'Beans', 'Goals': 1}
-    }
-
-    let prevWeek = {
-      week: 2,
-      stats: {'Jill': {'Salary': 100000, 'SalaryDelta': 5000}}
-    }
-
-    let salaryDeltas = calcSalaries(stats, prevWeek)
-    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(10000)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(110000)
-  })
-
-  it('gives the average salary delta to a player who misses week 1', function () {
+  it('gives absent player the average of their team salary delta', function () {
     let stats = {
       'Mike': {'Team': 'Beans'},
       'Jim': {'Team': 'Beans', 'Goals': 1},
@@ -88,7 +56,7 @@ describe('calcSalaries', function () {
 
   it('gives salary delta from the previous week if player is absent', function () {
     let stats = {
-      'Mike': {'Team': 'Beans'}
+      'Mike': {'Team': 'Beans', 'Goals': 1}
     }
 
     let prevWeek = {

--- a/test/routes/upload_test.js
+++ b/test/routes/upload_test.js
@@ -147,8 +147,8 @@ describe('POST /upload', function () {
     let w1 = await request.get(`${baseUrl}/weeks/1`, { json: true })
     let w2 = await request.get(`${baseUrl}/weeks/2`, { json: true })
 
-    expect(w1['stats']['Absent Player']['Salary']).to.equal(503625)
-    expect(w2['stats']['Absent Player']['Salary']).to.equal(507250)
+    expect(w1['stats']['Absent Player']['Salary']).to.equal(496250)
+    expect(w2['stats']['Absent Player']['Salary']).to.equal(492500)
   })
 
   // Note that it is a requirement the players are in the roster


### PR DESCRIPTION
Morgan Howard suggested this approach to handle salary for absent players and I liked it for its simplicity and because I think it might solve the problem of absent players being expensive in some of the middle teams right now (this might make the teams look even strength salary wise when they aren't). Some GMs have indicated this might be an issue so I wanted to investigate.

I implemented the average team salary (I also tried it with an 80% multiplier to further reduce the salary given to absent players)

I am happy with the algorithm as its simpler but it didn't seem to have a noticeable affect on the team salary distribution.

old calculation:
![week2_original](https://cloud.githubusercontent.com/assets/1965489/20512195/e2768cf4-b04b-11e6-8694-5bb4b21495f8.png)

new calculation:
![week2_team_avg](https://cloud.githubusercontent.com/assets/1965489/20512198/e9911b26-b04b-11e6-97a4-118410b2beae.png)

cc @patrickkenzie @keatesc

