### PR TITLE
Calc player

### DIFF
--- a/bin/compare.js
+++ b/bin/compare.js
@@ -1,0 +1,27 @@
+import _ from 'lodash'
+import fs from 'fs'
+import 'colour'
+
+// usage
+// ./node_modules/babel-cli/bin/babel-node.js bin/compare.js oldStats.json newStats.json
+
+let oldStats = JSON.parse(fs.readFileSync(process.argv[2])).stats
+let newStats = JSON.parse(fs.readFileSync(process.argv[3])).stats
+
+_.mapKeys(oldStats, (playerStats, playerName) => {
+  if (_.includes(playerName, '(S)')) return
+
+  let oldSalary = playerStats['Salary']
+  let newSalary = newStats[playerName]['Salary']
+  let diff = newSalary - oldSalary
+  let percentChange = Math.abs(diff) / oldSalary
+
+  // greater than 5% change
+  if (percentChange > 0.05) {
+    if (diff > 0) {
+      console.log(`${playerName} ${oldSalary} ^^^ ${newSalary}`.green)
+    } else {
+      console.log(`${playerName} ${oldSalary} vvv ${newSalary}`.red)
+    }
+  }
+})

--- a/bin/compare.js
+++ b/bin/compare.js
@@ -19,9 +19,9 @@ _.mapKeys(oldStats, (playerStats, playerName) => {
   // greater than 5% change
   if (percentChange > 0.05) {
     if (diff > 0) {
-      console.log(`${playerName} ${oldSalary} ^^^ ${newSalary}`.green)
+      console.log(`${playerName} ${oldSalary} --> ${newSalary}`.green)
     } else {
-      console.log(`${playerName} ${oldSalary} vvv ${newSalary}`.red)
+      console.log(`${playerName} ${oldSalary} --> ${newSalary}`.red)
     }
   }
 })

--- a/lib/calc_player.js
+++ b/lib/calc_player.js
@@ -1,0 +1,26 @@
+// @flow
+
+console.log(process.env.MONGODB_URI)
+const Db = require('monk')(process.env.MONGODB_URI)
+const Games = Db.get('games')
+
+let calcPlayer = async function (playerName: string) {
+  let games = await Games.find({}, {})
+
+  let player = { stats: [], averageSalaryDelta: 0 }
+
+  games.forEach((g) => {
+    let playerStats = g.stats[playerName]
+
+    if (playerStats) {
+      player.stats.append(playerStats)
+      player.averageSalaryDelta += playerStats['SalaryDelta']
+    }
+  })
+
+  player.averageSalaryDelta = player.averageSalaryDelta / player.stats.length
+
+  return player
+}
+
+module.exports = calcPlayer

--- a/lib/calc_player.js
+++ b/lib/calc_player.js
@@ -26,7 +26,7 @@ let calcPlayer = function (playerName: string, games: Array<any>) {
   })
 
   if (player.averageDelta > 0) {
-    player.averageDelta = player.averageDelta / player.stats.length
+    player.averageDelta = parseInt(player.averageDelta / player.stats.length)
   }
 
   return player

--- a/lib/calc_player.js
+++ b/lib/calc_player.js
@@ -1,24 +1,27 @@
 // @flow
 
-console.log(process.env.MONGODB_URI)
-const Db = require('monk')(process.env.MONGODB_URI)
-const Games = Db.get('games')
+const defaultSalary = 500000
 
-let calcPlayer = async function (playerName: string) {
-  let games = await Games.find({}, {})
-
-  let player = { stats: [], averageSalaryDelta: 0 }
+let calcPlayer = function (playerName: string, games: Array<any>) {
+  let player = {
+    stats: [],
+    prevSalary: defaultSalary,
+    averageDelta: 0
+  }
 
   games.forEach((g) => {
+    if (!g.stats) return
     let playerStats = g.stats[playerName]
+    if (!playerStats) return
 
-    if (playerStats) {
-      player.stats.append(playerStats)
-      player.averageSalaryDelta += playerStats['SalaryDelta']
-    }
+    player.stats.push(playerStats)
+    player.prevSalary = playerStats['Salary']
+    player.averageDelta += playerStats['SalaryDelta']
   })
 
-  player.averageSalaryDelta = player.averageSalaryDelta / player.stats.length
+  if (player.averageDelta > 0) {
+    player.averageDelta = player.averageDelta / player.stats.length
+  }
 
   return player
 }

--- a/lib/calc_player.js
+++ b/lib/calc_player.js
@@ -1,5 +1,7 @@
 // @flow
 
+import _ from 'lodash'
+
 const defaultSalary = 500000
 
 let calcPlayer = function (playerName: string, games: Array<any>) {
@@ -11,11 +13,15 @@ let calcPlayer = function (playerName: string, games: Array<any>) {
 
   games.forEach((g) => {
     if (!g.stats) return
+
     let playerStats = g.stats[playerName]
     if (!playerStats) return
 
-    player.stats.push(playerStats)
     player.prevSalary = playerStats['Salary']
+
+    // only use games they actually played when calculating their average
+    if (_.size(playerStats) <= 3) return
+    player.stats.push(playerStats)
     player.averageDelta += playerStats['SalaryDelta']
   })
 

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -78,7 +78,7 @@ let averageSalaryDelta = function (stats, team) {
     if (delta !== 0) nonZeroDeltas.push(delta)
   })
 
-  return _.sum(nonZeroDeltas) / nonZeroDeltas.length
+  return parseInt(_.sum(nonZeroDeltas) / nonZeroDeltas.length)
 }
 
 module.exports = calcSalaries

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -1,7 +1,6 @@
 // @flow
 
 import _ from 'lodash'
-import calcWeek from './calc_week'
 import calcPlayer from './calc_player'
 
 const playValues = {
@@ -26,20 +25,18 @@ const playValues = {
   'DPointsAgainst': 0
 }
 
-const defaultSalary = 500000
-
-let calcSalaries = async function (stats: any, prevWeekNum) {
+let calcSalaries = function (stats: any, games: Array<any>) {
   let playerSalaries = {}
-  let prevWeek = await calcWeek(prevWeekNum)
 
   _.mapValues(stats, function (playerStats, playerName) {
+    let player = calcPlayer(playerName, games)
     let salaryDelta = calcSalaryDelta(playerStats)
 
-    if (_gameNotPlayed(salaryDelta)) {
-      salaryDelta = calcPlayer(playerName).averageSalaryDelta
+    if (gameNotPlayed(salaryDelta)) {
+      salaryDelta = player.averageDelta
     }
 
-    let salary = previousSalary(prevWeek, playerName) + salaryDelta
+    let salary = player.prevSalary + salaryDelta
 
     playerSalaries[playerName] = {
       'SalaryDelta': salaryDelta,
@@ -50,7 +47,7 @@ let calcSalaries = async function (stats: any, prevWeekNum) {
   return playerSalaries
 }
 
-let _gameNotPlayed = function (salaryDelta) {
+let gameNotPlayed = function (salaryDelta) {
   return salaryDelta === 0
 }
 
@@ -61,26 +58,6 @@ let calcSalaryDelta = function (playerStats) {
   })
   values = _.values(values)
   return _.sum(values)
-}
-
-let previousSalary = function (prevWeek, playerName) {
-  if (!prevWeek) return defaultSalary
-
-  let player = prevWeek.stats[playerName]
-  if (player) return player['Salary']
-
-  // new player and it is not week 1
-  return prevAverageSalary(prevWeek)
-}
-
-let prevAverageSalary = function (prevWeek) {
-  let nonZeroValues = []
-
-  _.mapValues(prevWeek.stats, function (playerStats, playerName) {
-    if (playerStats['Salary']) nonZeroValues.push(playerStats['Salary'])
-  })
-
-  return _.sum(nonZeroValues) / nonZeroValues.length
 }
 
 module.exports = calcSalaries

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -36,6 +36,11 @@ let calcSalaries = function (stats: any, games: Array<any>) {
       salaryDelta = player.averageDelta
     }
 
+    // no history for the player
+    if (salaryDelta === 0) {
+      salaryDelta = averageSalaryDelta(stats, playerStats['Team'])
+    }
+
     let salary = player.prevSalary + salaryDelta
 
     playerSalaries[playerName] = {
@@ -58,6 +63,19 @@ let calcSalaryDelta = function (playerStats) {
   })
   values = _.values(values)
   return _.sum(values)
+}
+
+let averageSalaryDelta = function (stats, team) {
+  let teamStats = _.filter(stats, (s) => s['Team'] === team)
+
+  let nonZeroDeltas = []
+
+  _.mapValues(teamStats, function (playerStats, playerName) {
+    let delta = calcSalaryDelta(playerStats)
+    if (delta !== 0) nonZeroDeltas.push(delta)
+  })
+
+  return _.sum(nonZeroDeltas) / nonZeroDeltas.length
 }
 
 module.exports = calcSalaries

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -1,6 +1,8 @@
 // @flow
 
 import _ from 'lodash'
+import calcWeek from './calc_week'
+import calcPlayer from './calc_player'
 
 const playValues = {
   'Goals': 10000,
@@ -26,14 +28,15 @@ const playValues = {
 
 const defaultSalary = 500000
 
-let calcSalaries = function (stats: any, prevWeek: any) {
+let calcSalaries = async function (stats: any, prevWeekNum) {
   let playerSalaries = {}
+  let prevWeek = await calcWeek(prevWeekNum)
 
   _.mapValues(stats, function (playerStats, playerName) {
     let salaryDelta = calcSalaryDelta(playerStats)
 
     if (_gameNotPlayed(salaryDelta)) {
-      salaryDelta = previousSalaryDelta(playerName, prevWeek, stats)
+      salaryDelta = calcPlayer(playerName).averageSalaryDelta
     }
 
     let salary = previousSalary(prevWeek, playerName) + salaryDelta
@@ -60,19 +63,6 @@ let calcSalaryDelta = function (playerStats) {
   return _.sum(values)
 }
 
-let previousSalaryDelta = function (playerName, prevWeek, stats) {
-  // player missed week 1. assign average salaryDelta
-  if (!prevWeek) return averageSalaryDelta(stats)
-
-  // use prevWeeks salary delta
-  let playerStats = prevWeek.stats[playerName] || {}
-  let prevSalaryDelta = playerStats['SalaryDelta']
-  if (prevSalaryDelta) return prevSalaryDelta
-
-  // new player and it is not week 1
-  return averageSalaryDelta(stats)
-}
-
 let previousSalary = function (prevWeek, playerName) {
   if (!prevWeek) return defaultSalary
 
@@ -91,17 +81,6 @@ let prevAverageSalary = function (prevWeek) {
   })
 
   return _.sum(nonZeroValues) / nonZeroValues.length
-}
-
-let averageSalaryDelta = function (stats) {
-  let nonZeroDeltas = []
-
-  _.mapValues(stats, function (playerStats, playerName) {
-    let delta = calcSalaryDelta(playerStats)
-    if (delta !== 0) nonZeroDeltas.push(delta)
-  })
-
-  return _.sum(nonZeroDeltas) / nonZeroDeltas.length
 }
 
 module.exports = calcSalaries

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -27,7 +27,7 @@ const playValues = {
 
 let calcSalaries = function (stats: any, games: Array<any>) {
   let playerSalaries = {}
-  let weeksCount = _.max(_.map(games, (g) => g.week))
+  let weekNum = _.max(_.map(games, (g) => g.week))
 
   _.mapValues(stats, function (playerStats, playerName) {
     let player = calcPlayer(playerName, games)
@@ -44,8 +44,8 @@ let calcSalaries = function (stats: any, games: Array<any>) {
     }
 
     // new player, not week 1
-    if (player.prevSalary === 500000 && weeksCount > 1) {
-      player.prevSalary += salaryDelta * (weeksCount - 1)
+    if (player.prevSalary === 500000 && weekNum > 1) {
+      player.prevSalary += salaryDelta * (weekNum - 1)
     }
 
     let salary = player.prevSalary + salaryDelta

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -27,18 +27,25 @@ const playValues = {
 
 let calcSalaries = function (stats: any, games: Array<any>) {
   let playerSalaries = {}
+  let weeksCount = _.max(_.map(games, (g) => g.week))
 
   _.mapValues(stats, function (playerStats, playerName) {
     let player = calcPlayer(playerName, games)
     let salaryDelta = calcSalaryDelta(playerStats)
 
-    if (gameNotPlayed(salaryDelta)) {
+    // player was absent
+    if (salaryDelta === 0) {
       salaryDelta = player.averageDelta
     }
 
     // no history for the player
     if (salaryDelta === 0) {
       salaryDelta = averageSalaryDelta(stats, playerStats['Team'])
+    }
+
+    // new player, not week 1
+    if (player.prevSalary === 500000 && weeksCount > 1) {
+      player.prevSalary += salaryDelta * (weeksCount - 1)
     }
 
     let salary = player.prevSalary + salaryDelta
@@ -50,10 +57,6 @@ let calcSalaries = function (stats: any, games: Array<any>) {
   })
 
   return playerSalaries
-}
-
-let gameNotPlayed = function (salaryDelta) {
-  return salaryDelta === 0
 }
 
 let calcSalaryDelta = function (playerStats) {

--- a/lib/calc_week.js
+++ b/lib/calc_week.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash'
 
+console.log(process.env.MONGODB_URI) // undefined
 const Db = require('monk')(process.env.MONGODB_URI)
 const Games = Db.get('games')
 

--- a/lib/calc_week.js
+++ b/lib/calc_week.js
@@ -2,7 +2,6 @@
 
 import _ from 'lodash'
 
-console.log(process.env.MONGODB_URI) // undefined
 const Db = require('monk')(process.env.MONGODB_URI)
 const Games = Db.get('games')
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "babel-eslint": "^7.0.0",
     "chai": "^3.2.0",
+    "colour": "^0.7.1",
     "eslint": "^3.7.1",
     "eslint-config-standard": "^6.2.0",
     "eslint-plugin-flowtype": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "flow-bin": "^0.37.0",
     "glob": "^7.1.0",
     "loopnext": "0.0.3",
-    "mocha": "^2.3.2",
+    "mocha": "^3.2.0",
     "mocha-sinon": "^1.1.4",
     "nodemon": "^1.10.2",
     "sinon": "^1.17.6",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-react": "^6.4.1",
     "eslint-plugin-standard": "^2.0.1",
-    "flow-bin": "^0.33.0",
+    "flow-bin": "^0.37.0",
     "glob": "^7.1.0",
     "loopnext": "0.0.3",
     "mocha": "^2.3.2",

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -49,7 +49,9 @@ router.post('/upload', async function (req, res) {
   let playerTeams = calcTeams(game.teams, game.stats)
   game.stats = _.merge(game.stats, playerTeams)
 
-  let playerSalaries = await calcSalaries(stats, game.week - 1)
+  let games = await Games.find({}, {sort: { week: 1 }})
+
+  let playerSalaries = calcSalaries(stats, games)
   game.stats = _.merge(game.stats, playerSalaries)
 
   await saveGame(game)

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -10,7 +10,6 @@ import _ from 'lodash'
 import calcStats from '../lib/calc_stats'
 import calcSalaries from '../lib/calc_salaries'
 import calcTeams from '../lib/calc_teams'
-import calcWeek from '../lib/calc_week'
 import calcWeekNum from '../lib/calc_week_num'
 
 /**
@@ -44,16 +43,13 @@ router.post('/upload', async function (req, res) {
 
   await createGame(game)
 
-  let prevWeekNum = game.week - 1
-  let prevWeek = await calcWeek(prevWeekNum)
-
   let stats = calcStats(game.event_string)
   game.stats = stats
 
   let playerTeams = calcTeams(game.teams, game.stats)
   game.stats = _.merge(game.stats, playerTeams)
 
-  let playerSalaries = calcSalaries(stats, prevWeek)
+  let playerSalaries = await calcSalaries(stats, game.week - 1)
   game.stats = _.merge(game.stats, playerSalaries)
 
   await saveGame(game)

--- a/test/files/week1_game2.json
+++ b/test/files/week1_game2.json
@@ -10,7 +10,7 @@
             "Rob Ives",
             "Simon Berry",
             "Brent Burton",
-            "Christopher Castonguay",
+            "Chris Sullivan",
             "Martin Cloake",
             "Mark Donahue",
             "Richard Gregory",
@@ -210,14 +210,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:22:16 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Rob Ives"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:22:20 PM",
                     "secondActor": "Simon Berry",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "THROWAWAY",
@@ -317,7 +317,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -381,7 +381,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -464,14 +464,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:28:48 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:28:54 PM",
                     "secondActor": "Hope Celani",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -491,7 +491,7 @@
                 "Richard Gregory",
                 "Hope Celani",
                 "Janet Ibit",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -620,14 +620,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:33:47 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Justine Price"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:33:52 PM",
                     "secondActor": "Rob Ives",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -653,7 +653,7 @@
                 "Richard Gregory",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -736,7 +736,7 @@
                 "Ariel Untiveros",
                 "Janet Ibit",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -856,13 +856,13 @@
                 {
                     "type": "DEFENSE",
                     "timestamp": "Nov 7, 2016 8:38:35 PM",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:38:37 PM",
                     "secondActor": "Mark Donahue",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "POINT",
@@ -876,7 +876,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -957,14 +957,14 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:40:48 PM",
                     "secondActor": "Mark Donahue",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -975,7 +975,7 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:41:02 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Justine Price"
                 },
                 {
@@ -986,13 +986,13 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:41:07 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Hope Celani"
                 },
                 {
                     "type": "POINT",
                     "timestamp": "Nov 7, 2016 8:41:08 PM",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 }
             ],
             "defensePlayers": [
@@ -1082,20 +1082,20 @@
                 "Richard Gregory",
                 "Janet Ibit",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:43:43 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:43:47 PM",
                     "secondActor": "Simon Berry",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1313,14 +1313,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:47:42 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:47:45 PM",
                     "secondActor": "Simon Berry",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1343,14 +1343,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:47:57 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Janet Ibit"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:48:01 PM",
                     "secondActor": "Hope Celani",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "POINT",
@@ -1364,7 +1364,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -1532,20 +1532,20 @@
                 "Richard Gregory",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:56:45 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:56:50 PM",
                     "secondActor": "Richard Gregory",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1556,14 +1556,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:56:59 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Mark Donahue"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:57:02 PM",
                     "secondActor": "Hope Celani",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1580,14 +1580,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:57:19 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 8:57:23 PM",
                     "secondActor": "Justine Price",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1660,7 +1660,7 @@
                 "Richard Gregory",
                 "Janet Ibit",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -1714,13 +1714,13 @@
                 {
                     "type": "DEFENSE",
                     "timestamp": "Nov 7, 2016 9:00:34 PM",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:00:36 PM",
                     "secondActor": "Simon Berry",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1782,7 +1782,7 @@
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:01:10 PM",
                     "secondActor": "Ariel Untiveros",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1793,14 +1793,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:01:21 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Hope Celani"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:01:23 PM",
                     "secondActor": "Rob Ives",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1879,7 +1879,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -2025,7 +2025,7 @@
                 "Richard Gregory",
                 "Janet Ibit",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -2143,7 +2143,7 @@
                 {
                     "type": "THROWAWAY",
                     "timestamp": "Nov 7, 2016 9:08:00 PM",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2250,7 +2250,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -2366,7 +2366,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -2376,14 +2376,14 @@
                 "Mark Donahue",
                 "Hope Celani",
                 "Janet Ibit",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:13:05 PM",
                     "secondActor": "Rob Ives",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2394,14 +2394,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:13:11 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Janet Ibit"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:13:18 PM",
                     "secondActor": "Mark Donahue",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "THROWAWAY",
@@ -2501,14 +2501,14 @@
                 "Mark Donahue",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:15:44 PM",
                     "secondActor": "Rob Ives",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2519,14 +2519,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:15:56 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Justine Price"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:15:59 PM",
                     "secondActor": "Rob Ives",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "DROP",
@@ -2547,13 +2547,13 @@
                 {
                     "type": "DEFENSE",
                     "timestamp": "Nov 7, 2016 9:16:14 PM",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:16:18 PM",
                     "secondActor": "Simon Berry",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "THROWAWAY",
@@ -2669,7 +2669,7 @@
                 "Ariel Untiveros",
                 "Janet Ibit",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -2716,14 +2716,14 @@
                 "Richard Gregory",
                 "Hope Celani",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:22:17 PM",
                     "secondActor": "Justine Price",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2746,14 +2746,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:22:27 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:22:32 PM",
                     "secondActor": "Simon Berry",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2782,14 +2782,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:22:52 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Justine Price"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:23:21 PM",
                     "secondActor": "Brent Burton",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2800,14 +2800,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:23:29 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:23:35 PM",
                     "secondActor": "Brent Burton",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2874,7 +2874,7 @@
                 "Ariel Untiveros",
                 "Janet Ibit",
                 "Justine Price",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -2896,14 +2896,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:26:04 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Janet Ibit"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:26:08 PM",
                     "secondActor": "Ariel Untiveros",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2914,14 +2914,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:26:14 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Justine Price"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:26:20 PM",
                     "secondActor": "Justine Price",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2938,14 +2938,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:26:33 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Janet Ibit"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:26:38 PM",
                     "secondActor": "Ariel Untiveros",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "POINT",
@@ -3018,14 +3018,14 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "Chris Sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:28:36 PM",
                     "secondActor": "Ariel Untiveros",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -3088,13 +3088,13 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 7, 2016 9:30:32 PM",
-                    "secondActor": "Chris Sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Ariel Untiveros"
                 },
                 {
                     "type": "THROWAWAY",
                     "timestamp": "Nov 7, 2016 9:30:37 PM",
-                    "firstActor": "Chris Sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -3266,7 +3266,7 @@
         "Direction,>>>>>>,",
         "Throw Away,Andrea Proulx,Pass,Sina Dee,Pass,Jon Rowe,Pass,Sina Dee,",
         "Direction,<<<<<<,",
-        "Throw Away,Simon Berry,Pass,Chris Sullivan(S),Pass,Rob Ives,Pass,Janet Ibit,",
+        "Throw Away,Simon Berry,Pass,Chris Sullivan,Pass,Rob Ives,Pass,Janet Ibit,",
         "Direction,>>>>>>,",
         "Throw Away,Andrea Proulx,Pass,Sina Dee,Pass,Frederic Caron(S),Pass,Samantha Lee,Pass,Frederic Caron(S),Pass,Samantha Lee,Pass,Andrea Proulx,Pass,Frederic Caron(S),Pass,Sina Dee,",
         "Direction,<<<<<<,",
@@ -3285,7 +3285,7 @@
         "-1,Ariel Untiveros,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "Drop,Brent Burton,Pass,Mark Donahue,",
         "Direction,>>>>>>,",
@@ -3315,12 +3315,12 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Jon Rowe,Pass,Nicholas Aghajanian,Pass,Andrea Proulx,Pass,Sina Dee,",
         "Direction,<<<<<<,",
         "D,Brent Burton,",
-        "POINT,Rob Ives,Pass,Hope Celani,Pass,Chris Sullivan(S),Pass,Richard Gregory,Pass,Brent Burton,",
+        "POINT,Rob Ives,Pass,Hope Celani,Pass,Chris Sullivan,Pass,Richard Gregory,Pass,Brent Burton,",
         "-1,Nicholas Aghajanian,",
         "-1,Sina Dee,",
         "-1,Jon Rowe,",
@@ -3332,7 +3332,7 @@
         "+1,Richard Gregory,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Drop,Angela Mueller,Pass,Samantha Lee,Pass,Dan Thomson,Pass,Sina Dee,Pass,Angela Mueller,Pass,Sina Dee,",
         "Direction,<<<<<<,",
@@ -3352,7 +3352,7 @@
         "Direction,>>>>>>,",
         "Throw Away,Jon Rowe,Pass,Morgan Howard,Pass,Frederic Caron(S),",
         "Direction,<<<<<<,",
-        "POINT,Justine Price,Pass,Brent Burton,Pass,Rob Ives,Pass,Chris Sullivan(S),Pass,Justine Price,Pass,Richard Gregory,",
+        "POINT,Justine Price,Pass,Brent Burton,Pass,Rob Ives,Pass,Chris Sullivan,Pass,Justine Price,Pass,Richard Gregory,",
         "-1,Morgan Howard,",
         "-1,Jon Rowe,",
         "-1,Dan Thomson,",
@@ -3364,7 +3364,7 @@
         "+1,Richard Gregory,",
         "+1,Hope Celani,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Sina Dee,Pass,Frederic Caron(S),Pass,Samantha Lee,Pass,Frederic Caron(S),Pass,Angela Mueller,Pass,Samantha Lee,Pass,Sina Dee,Pass,Samantha Lee,Pass,Sina Dee,",
         "+1,Nicholas Aghajanian,",
@@ -3392,7 +3392,7 @@
         "+1,Ariel Untiveros,",
         "+1,Janet Ibit,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Drop,Morgan Howard,Pass,Frederic Caron(S),",
         "Direction,<<<<<<,",
@@ -3412,8 +3412,8 @@
         "Direction,>>>>>>,",
         "Throw Away,Frederic Caron(S),Pass,Sina Dee,",
         "Direction,<<<<<<,",
-        "D,Chris Sullivan(S),",
-        "POINT,Mark Donahue,Pass,Chris Sullivan(S),",
+        "D,Chris Sullivan,",
+        "POINT,Mark Donahue,Pass,Chris Sullivan,",
         "-1,Nicholas Aghajanian,",
         "-1,Sina Dee,",
         "-1,Jon Rowe,",
@@ -3425,7 +3425,7 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Drop,Morgan Howard,Pass,Sina Dee,",
         "Direction,<<<<<<,",
@@ -3445,7 +3445,7 @@
         "-1,Janet Ibit,",
         "-1,Justine Price,",
         "Direction,<<<<<<,",
-        "POINT,Chris Sullivan(S),Pass,Hope Celani,Pass,Justine Price,Pass,Mark Donahue,Pass,Chris Sullivan(S),",
+        "POINT,Chris Sullivan,Pass,Hope Celani,Pass,Justine Price,Pass,Mark Donahue,Pass,Chris Sullivan,",
         "-1,Morgan Howard,",
         "-1,Jon Rowe,",
         "-1,Dan Thomson,",
@@ -3457,7 +3457,7 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Frederic Caron(S),Pass,Samantha Lee,Pass,Angela Mueller,Pass,Sina Dee,",
         "Direction,<<<<<<,",
@@ -3477,7 +3477,7 @@
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
         "Direction,<<<<<<,",
-        "Drop,Justine Price,Pass,Simon Berry,Pass,Richard Gregory,Pass,Mark Donahue,Pass,Simon Berry,Pass,Chris Sullivan(S),Pass,Richard Gregory,",
+        "Drop,Justine Price,Pass,Simon Berry,Pass,Richard Gregory,Pass,Mark Donahue,Pass,Simon Berry,Pass,Chris Sullivan,Pass,Richard Gregory,",
         "Direction,>>>>>>,",
         "Throw Away,Morgan Howard,Pass,Dan Thomson,Pass,Sina Dee,Pass,Christine Beals,Pass,Andrea Proulx,",
         "Direction,<<<<<<,",
@@ -3496,7 +3496,7 @@
         "-1,Richard Gregory,",
         "-1,Janet Ibit,",
         "-1,Justine Price,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "POINT,Rob Ives,Pass,Ariel Untiveros,Pass,Brent Burton,Pass,Ariel Untiveros,Pass,Justine Price,",
         "-1,Morgan Howard,",
@@ -3514,7 +3514,7 @@
         "Direction,>>>>>>,",
         "Throw Away,Sina Dee,Pass,Frederic Caron(S),Pass,Nicholas Aghajanian,Pass,Frederic Caron(S),Pass,Sina Dee,",
         "Direction,<<<<<<,",
-        "POINT,Hope Celani,Pass,Chris Sullivan(S),Pass,Janet Ibit,Pass,Richard Gregory,Pass,Ariel Untiveros,Pass,Simon Berry,Pass,Chris Sullivan(S),Pass,Richard Gregory,Pass,Ariel Untiveros,",
+        "POINT,Hope Celani,Pass,Chris Sullivan,Pass,Janet Ibit,Pass,Richard Gregory,Pass,Ariel Untiveros,Pass,Simon Berry,Pass,Chris Sullivan,Pass,Richard Gregory,Pass,Ariel Untiveros,",
         "-1,Nicholas Aghajanian,",
         "-1,Sina Dee,",
         "-1,Jon Rowe,",
@@ -3526,7 +3526,7 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Time,Half,",
         "Pull,Brent Burton,",
@@ -3551,7 +3551,7 @@
         "-1,Janet Ibit,",
         "-1,Justine Price,",
         "Direction,<<<<<<,",
-        "POINT,Mark Donahue,Pass,Simon Berry,Pass,Justine Price,Pass,Chris Sullivan(S),Pass,Richard Gregory,Pass,Justine Price,Pass,Hope Celani,Pass,Chris Sullivan(S),Pass,Mark Donahue,Pass,Richard Gregory,Pass,Chris Sullivan(S),Pass,Richard Gregory,",
+        "POINT,Mark Donahue,Pass,Simon Berry,Pass,Justine Price,Pass,Chris Sullivan,Pass,Richard Gregory,Pass,Justine Price,Pass,Hope Celani,Pass,Chris Sullivan,Pass,Mark Donahue,Pass,Richard Gregory,Pass,Chris Sullivan,Pass,Richard Gregory,",
         "-1,Morgan Howard,",
         "-1,Jon Rowe,",
         "-1,Dan Thomson,",
@@ -3563,7 +3563,7 @@
         "+1,Richard Gregory,",
         "+1,Hope Celani,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Sina Dee,Pass,Frederic Caron(S),Pass,Sina Dee,",
         "+1,Nicholas Aghajanian,",
@@ -3591,18 +3591,18 @@
         "+1,Richard Gregory,",
         "+1,Janet Ibit,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Angela Mueller,Pass,Frederic Caron(S),",
         "Direction,<<<<<<,",
-        "D,Chris Sullivan(S),",
-        "Throw Away,Justine Price,Pass,Simon Berry,Pass,Chris Sullivan(S),",
+        "D,Chris Sullivan,",
+        "Throw Away,Justine Price,Pass,Simon Berry,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "D,Frederic Caron(S),",
         "Throw Away,Dan Thomson,Pass,Samantha Lee,Pass,Jon Rowe,Pass,Frederic Caron(S),Pass,Dan Thomson,Pass,Frederic Caron(S),",
         "Direction,<<<<<<,",
         "D,Simon Berry,",
-        "Throw Away,Hope Celani,Pass,Simon Berry,Pass,Rob Ives,Pass,Chris Sullivan(S),Pass,Hope Celani,Pass,Ariel Untiveros,Pass,Chris Sullivan(S),",
+        "Throw Away,Hope Celani,Pass,Simon Berry,Pass,Rob Ives,Pass,Chris Sullivan,Pass,Hope Celani,Pass,Ariel Untiveros,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Jon Rowe,Pass,Angela Mueller,Pass,Dan Thomson,Pass,Frederic Caron(S),Pass,Dan Thomson,Pass,Morgan Howard,Pass,Frederic Caron(S),Pass,Dan Thomson,Pass,Frederic Caron(S),",
         "+1,Morgan Howard,",
@@ -3616,7 +3616,7 @@
         "-1,Ariel Untiveros,",
         "-1,Hope Celani,",
         "-1,Justine Price,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "POINT,Mark Donahue,Pass,Richard Gregory,Pass,Brent Burton,Pass,Richard Gregory,Pass,Mark Donahue,Pass,Brent Burton,Pass,Mark Donahue,Pass,Janet Ibit,",
         "-1,Nicholas Aghajanian,",
@@ -3644,7 +3644,7 @@
         "-1,Richard Gregory,",
         "-1,Janet Ibit,",
         "-1,Justine Price,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "POINT,Rob Ives,Pass,Ariel Untiveros,Pass,Hope Celani,Pass,Justine Price,Pass,Brent Burton,Pass,Justine Price,Pass,Rob Ives,Pass,Mark Donahue,Pass,Justine Price,Pass,Ariel Untiveros,Pass,Rob Ives,",
         "-1,Morgan Howard,",
@@ -3662,7 +3662,7 @@
         "Direction,>>>>>>,",
         "Throw Away,Sina Dee,Pass,Angela Mueller,Pass,Sina Dee,",
         "Direction,<<<<<<,",
-        "Throw Away,Chris Sullivan(S),",
+        "Throw Away,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Jon Rowe,Pass,Nicholas Aghajanian,Pass,Angela Mueller,Pass,Sina Dee,Pass,Samantha Lee,Pass,Sina Dee,",
         "Direction,<<<<<<,",
@@ -3681,7 +3681,7 @@
         "-1,Ariel Untiveros,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "POINT,Rob Ives,Pass,Brent Burton,Pass,Mark Donahue,Pass,Justine Price,Pass,Rob Ives,Pass,Justine Price,Pass,Brent Burton,Pass,Mark Donahue,Pass,Janet Ibit,",
         "-1,Nicholas Aghajanian,",
@@ -3709,9 +3709,9 @@
         "-1,Ariel Untiveros,",
         "-1,Hope Celani,",
         "-1,Justine Price,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
-        "Throw Away,Mark Donahue,Pass,Chris Sullivan(S),Pass,Janet Ibit,Pass,Rob Ives,Pass,Chris Sullivan(S),",
+        "Throw Away,Mark Donahue,Pass,Chris Sullivan,Pass,Janet Ibit,Pass,Rob Ives,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "D,Andrea Proulx,",
         "POINT,Jon Rowe,Pass,Frederic Caron(S),Pass,Andrea Proulx,Pass,Sina Dee,Pass,Andrea Proulx,",
@@ -3726,7 +3726,7 @@
         "-1,Mark Donahue,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "Throw Away,Brent Burton,Pass,Richard Gregory,Pass,Janet Ibit,",
         "Direction,>>>>>>,",
@@ -3744,12 +3744,12 @@
         "-1,Janet Ibit,",
         "-1,Justine Price,",
         "Direction,<<<<<<,",
-        "Drop,Rob Ives,Pass,Chris Sullivan(S),Pass,Justine Price,Pass,Rob Ives,Pass,Chris Sullivan(S),",
+        "Drop,Rob Ives,Pass,Chris Sullivan,Pass,Justine Price,Pass,Rob Ives,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Christine Beals,Pass,Frederic Caron(S),",
         "Direction,<<<<<<,",
-        "D,Chris Sullivan(S),",
-        "Throw Away,Simon Berry,Pass,Chris Sullivan(S),",
+        "D,Chris Sullivan,",
+        "Throw Away,Simon Berry,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Morgan Howard,",
         "Direction,<<<<<<,",
@@ -3768,7 +3768,7 @@
         "-1,Mark Donahue,",
         "-1,Hope Celani,",
         "-1,Justine Price,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "Throw Away,Brent Burton,",
         "Direction,>>>>>>,",
@@ -3801,9 +3801,9 @@
         "-1,Ariel Untiveros,",
         "-1,Janet Ibit,",
         "-1,Justine Price,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
-        "POINT,Simon Berry,Pass,Brent Burton,Pass,Chris Sullivan(S),Pass,Richard Gregory,Pass,Brent Burton,Pass,Chris Sullivan(S),Pass,Justine Price,Pass,Brent Burton,Pass,Richard Gregory,Pass,Brent Burton,Pass,Simon Berry,Pass,Chris Sullivan(S),Pass,Richard Gregory,Pass,Brent Burton,Pass,Simon Berry,Pass,Justine Price,Pass,Chris Sullivan(S),",
+        "POINT,Simon Berry,Pass,Brent Burton,Pass,Chris Sullivan,Pass,Richard Gregory,Pass,Brent Burton,Pass,Chris Sullivan,Pass,Justine Price,Pass,Brent Burton,Pass,Richard Gregory,Pass,Brent Burton,Pass,Simon Berry,Pass,Chris Sullivan,Pass,Richard Gregory,Pass,Brent Burton,Pass,Simon Berry,Pass,Justine Price,Pass,Chris Sullivan,",
         "-1,Morgan Howard,",
         "-1,Jon Rowe,",
         "-1,Dan Thomson,",
@@ -3815,7 +3815,7 @@
         "+1,Richard Gregory,",
         "+1,Hope Celani,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Sina Dee,Pass,Frederic Caron(S),Pass,Sina Dee,",
         "+1,Nicholas Aghajanian,",
@@ -3835,7 +3835,7 @@
         "Direction,>>>>>>,",
         "Throw Away,Angela Mueller,",
         "Direction,<<<<<<,",
-        "POINT,Ariel Untiveros,Pass,Chris Sullivan(S),Pass,Janet Ibit,Pass,Ariel Untiveros,Pass,Justine Price,Pass,Chris Sullivan(S),Pass,Justine Price,Pass,Ariel Untiveros,Pass,Chris Sullivan(S),Pass,Janet Ibit,",
+        "POINT,Ariel Untiveros,Pass,Chris Sullivan,Pass,Janet Ibit,Pass,Ariel Untiveros,Pass,Justine Price,Pass,Chris Sullivan,Pass,Justine Price,Pass,Ariel Untiveros,Pass,Chris Sullivan,Pass,Janet Ibit,",
         "-1,Nicholas Aghajanian,",
         "-1,Sina Dee,",
         "-1,Morgan Howard,",
@@ -3847,7 +3847,7 @@
         "+1,Ariel Untiveros,",
         "+1,Janet Ibit,",
         "+1,Justine Price,",
-        "+1,Chris Sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Andrea Proulx,Pass,Frederic Caron(S),Pass,Christine Beals,Pass,Dan Thomson,Pass,Andrea Proulx,",
         "+1,Morgan Howard,",
@@ -3863,11 +3863,11 @@
         "-1,Hope Celani,",
         "-1,Justine Price,",
         "Direction,<<<<<<,",
-        "Throw Away,Janet Ibit,Pass,Mark Donahue,Pass,Ariel Untiveros,Pass,Chris Sullivan(S),",
+        "Throw Away,Janet Ibit,Pass,Mark Donahue,Pass,Ariel Untiveros,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Drop,Sina Dee,Pass,Angela Mueller,Pass,Nicholas Aghajanian,Pass,Angela Mueller,Pass,Sina Dee,Pass,Frederic Caron(S),Pass,Sina Dee,",
         "Direction,<<<<<<,",
-        "Throw Away,Chris Sullivan(S),Pass,Ariel Untiveros,",
+        "Throw Away,Chris Sullivan,Pass,Ariel Untiveros,",
         "Direction,>>>>>>,",
         "POINT,Nicholas Aghajanian,Pass,Frederic Caron(S),Pass,Angela Mueller,Pass,Sina Dee,Pass,Frederic Caron(S),Pass,Sina Dee,",
         "+1,Nicholas Aghajanian,",
@@ -3881,7 +3881,7 @@
         "-1,Ariel Untiveros,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,Chris Sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "Throw Away,Mark Donahue,Pass,Richard Gregory,Pass,Mark Donahue,Pass,Brent Burton,Pass,Justine Price,Pass,Richard Gregory,",
         "Direction,>>>>>>,",

--- a/test/files/week2_game1.json
+++ b/test/files/week2_game1.json
@@ -10,7 +10,7 @@
             "Rob Ives",
             "Simon Berry",
             "Brent Burton",
-            "Christopher Castonguay",
+            "Chris Sullivan",
             "Martin Cloake",
             "Mark Donahue",
             "Richard Gregory",
@@ -105,7 +105,7 @@
                 "Richard Gregory",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -279,7 +279,7 @@
                 "Mark Donahue",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -289,14 +289,14 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:15:31 AM",
                     "secondActor": "Hope Celani",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -502,7 +502,7 @@
                 "Richard Gregory",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -531,7 +531,7 @@
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:19:36 AM",
                     "secondActor": "Mark Donahue",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -703,7 +703,7 @@
                 {
                     "type": "THROWAWAY",
                     "timestamp": "Nov 15, 2016 1:22:45 AM",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "THROWAWAY",
@@ -718,14 +718,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:23:05 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Ariel Untiveros"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:23:06 AM",
                     "secondActor": "Mark Donahue",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -745,7 +745,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -842,7 +842,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -852,7 +852,7 @@
                 "Richard Gregory",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -864,14 +864,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:26:41 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Rob Ives"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:26:56 AM",
                     "secondActor": "Justine Price",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -940,14 +940,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:27:36 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Justine Price"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:27:42 AM",
                     "secondActor": "Justine Price",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1032,14 +1032,14 @@
                 "Richard Gregory",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:29:44 AM",
                     "secondActor": "Justine Price",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1061,7 +1061,7 @@
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:30:13 AM",
                     "secondActor": "Richard Gregory",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1110,14 +1110,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:32:47 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:32:48 AM",
                     "secondActor": "Justine Price",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1128,26 +1128,26 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:32:54 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Nina Ramic"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:32:56 AM",
                     "secondActor": "Justine Price",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:33:02 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Justine Price"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:33:06 AM",
                     "secondActor": "Nina Ramic",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1219,7 +1219,7 @@
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:34:23 AM",
                     "secondActor": "Brent Burton",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1230,14 +1230,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:34:37 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Janet Ibit"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:34:42 AM",
                     "secondActor": "Brent Burton",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1257,7 +1257,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -1401,7 +1401,7 @@
                 "Mark Donahue",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -1477,7 +1477,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -1488,13 +1488,13 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:45:28 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Rob Ives"
                 },
                 {
                     "type": "THROWAWAY",
                     "timestamp": "Nov 15, 2016 1:45:37 AM",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "DEFENSE",
@@ -1521,13 +1521,13 @@
                 {
                     "type": "DEFENSE",
                     "timestamp": "Nov 15, 2016 1:46:07 AM",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:46:11 AM",
                     "secondActor": "Janet Ibit",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -1538,13 +1538,13 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:46:21 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Rob Ives"
                 },
                 {
                     "type": "POINT",
                     "timestamp": "Nov 15, 2016 1:46:23 AM",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 }
             ],
             "defensePlayers": [
@@ -1737,7 +1737,7 @@
                 "Ariel Untiveros",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -1858,13 +1858,13 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:53:54 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Brent Burton"
                 },
                 {
                     "type": "THROWAWAY",
                     "timestamp": "Nov 15, 2016 1:54:01 AM",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "DEFENSE",
@@ -1932,7 +1932,7 @@
                 "Martin Cloake",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -1991,7 +1991,7 @@
                 "Richard Gregory",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -2039,13 +2039,13 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 1:57:36 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Martin Cloake"
                 },
                 {
                     "type": "POINT",
                     "timestamp": "Nov 15, 2016 1:57:59 AM",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 }
             ],
             "defensePlayers": [
@@ -2180,7 +2180,7 @@
                 "Richard Gregory",
                 "Hope Celani",
                 "Janet Ibit",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -2190,14 +2190,14 @@
                 "Ariel Untiveros",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 2:01:17 AM",
                     "secondActor": "Ariel Untiveros",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2332,14 +2332,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 2:04:45 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Nina Ramic"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 2:04:54 AM",
                     "secondActor": "Richard Gregory",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "POINT",
@@ -2353,7 +2353,7 @@
                 "Richard Gregory",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -2610,14 +2610,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 2:13:08 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Ariel Untiveros"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 2:13:08 AM",
                     "secondActor": "Nina Ramic",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2628,14 +2628,14 @@
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 2:13:14 AM",
-                    "secondActor": "chris sullivan(S)",
+                    "secondActor": "Chris Sullivan",
                     "firstActor": "Richard Gregory"
                 },
                 {
                     "type": "PASS",
                     "timestamp": "Nov 15, 2016 2:13:16 AM",
                     "secondActor": "Justine Price",
-                    "firstActor": "chris sullivan(S)"
+                    "firstActor": "Chris Sullivan"
                 },
                 {
                     "type": "PASS",
@@ -2655,7 +2655,7 @@
                 "Ariel Untiveros",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ]
         },
         {
@@ -2732,7 +2732,7 @@
                 "Ariel Untiveros",
                 "Justine Price",
                 "Nina Ramic",
-                "chris sullivan(S)"
+                "Chris Sullivan"
             ],
             "events": [
                 {
@@ -2779,7 +2779,7 @@
         "-1,Richard Gregory,",
         "-1,Justine Price,",
         "-1,Nina Ramic,",
-        "-1,chris sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "Throw Away,Janet Ibit,Pass,Ariel Untiveros,Pass,Janet Ibit,Pass,Richard Gregory,Pass,Rob Ives,Pass,Richard Gregory,Pass,Janet Ibit,Pass,Richard Gregory,Pass,Rob Ives,Pass,Brent Burton,",
         "Direction,>>>>>>,",
@@ -2811,9 +2811,9 @@
         "-1,Mark Donahue,",
         "-1,Justine Price,",
         "-1,Nina Ramic,",
-        "-1,chris sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
-        "POINT,Ariel Untiveros,Pass,Rob Ives,Pass,Hope Celani,Pass,chris sullivan(S),",
+        "POINT,Ariel Untiveros,Pass,Rob Ives,Pass,Hope Celani,Pass,Chris Sullivan,",
         "-1,Kevin Hughes,",
         "-1,Ryan Mussell,",
         "-1,Jonathan Pindur,",
@@ -2825,7 +2825,7 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Trevor Ryan,Pass,Jay Thor Turner,Pass,Trevor Ryan,Pass,Tanya Gallant,Pass,Megan Robb,Pass,Patrick Kenzie,Pass,Jason Fraser,Pass,Megan Robb,Pass,Patrick Kenzie,",
         "Direction,<<<<<<,",
@@ -2851,7 +2851,7 @@
         "Direction,>>>>>>,",
         "Drop,Jonathan Pindur,Pass,Kevin Hughes,Pass,Jessie Robinson,",
         "Direction,<<<<<<,",
-        "POINT,Richard Gregory,Pass,Janet Ibit,Pass,Hope Celani,Pass,Mark Donahue,Pass,Rob Ives,Pass,Mark Donahue,Pass,chris sullivan(S),",
+        "POINT,Richard Gregory,Pass,Janet Ibit,Pass,Hope Celani,Pass,Mark Donahue,Pass,Rob Ives,Pass,Mark Donahue,Pass,Chris Sullivan,",
         "-1,Kevin Hughes,",
         "-1,Ryan Mussell,",
         "-1,Jonathan Pindur,",
@@ -2863,7 +2863,7 @@
         "+1,Richard Gregory,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Jessie Robinson,",
         "Direction,<<<<<<,",
@@ -2884,12 +2884,12 @@
         "Direction,>>>>>>,",
         "Drop,Kevin Hughes,Pass,Ryan Mussell,Pass,Megan Robb,Pass,Kevin Hughes,Pass,Ryan Mussell,Pass,Tanya Gallant,Pass,Megan Robb,Pass,Kevin Hughes,",
         "Direction,<<<<<<,",
-        "Throw Away,chris sullivan(S),",
+        "Throw Away,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Tanya Gallant,",
         "Direction,<<<<<<,",
         "D,Ariel Untiveros,",
-        "POINT,Richard Gregory,Pass,Mark Donahue,Pass,chris sullivan(S),Pass,Ariel Untiveros,",
+        "POINT,Richard Gregory,Pass,Mark Donahue,Pass,Chris Sullivan,Pass,Ariel Untiveros,",
         "-1,Kevin Hughes,",
         "-1,Ryan Mussell,",
         "-1,Jonathan Pindur,",
@@ -2901,7 +2901,7 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Jessie Robinson,",
         "Direction,<<<<<<,",
@@ -2931,13 +2931,13 @@
         "-1,Ariel Untiveros,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,chris sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
-        "Drop,Richard Gregory,Pass,Justine Price,Pass,chris sullivan(S),Pass,Rob Ives,Pass,Richard Gregory,",
+        "Drop,Richard Gregory,Pass,Justine Price,Pass,Chris Sullivan,Pass,Rob Ives,Pass,Richard Gregory,",
         "Direction,>>>>>>,",
         "Drop,Jay Thor Turner,Pass,Patrick Kenzie,Pass,Trevor Ryan,Pass,Megan Robb,Pass,Patrick Kenzie,Pass,Trevor Ryan,Pass,Tanya Gallant,Pass,Patrick Kenzie,",
         "Direction,<<<<<<,",
-        "POINT,Martin Cloake,Pass,Justine Price,Pass,chris sullivan(S),Pass,Justine Price,Pass,Rob Ives,",
+        "POINT,Martin Cloake,Pass,Justine Price,Pass,Chris Sullivan,Pass,Justine Price,Pass,Rob Ives,",
         "-1,Jason Fraser,",
         "-1,Patrick Kenzie,",
         "-1,Trevor Ryan,",
@@ -2949,7 +2949,7 @@
         "+1,Richard Gregory,",
         "+1,Justine Price,",
         "+1,Nina Ramic,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Kevin Hughes,Pass,Jonathan Pindur,Pass,Ryan Mussell,Pass,Jonathan Pindur,Pass,Kevin Hughes,Pass,Jessie Robinson,",
         "+1,Kevin Hughes,",
@@ -2965,17 +2965,17 @@
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
         "Direction,<<<<<<,",
-        "Throw Away,Nina Ramic,Pass,Justine Price,Pass,chris sullivan(S),",
+        "Throw Away,Nina Ramic,Pass,Justine Price,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Jessie Robinson,",
         "Direction,<<<<<<,",
-        "Throw Away,Richard Gregory,Pass,Justine Price,Pass,Richard Gregory,Pass,chris sullivan(S),",
+        "Throw Away,Richard Gregory,Pass,Justine Price,Pass,Richard Gregory,Pass,Chris Sullivan,",
         "Direction,>>>>>>,",
         "D,Trevor Ryan,",
         "Throw Away,Tanya Gallant,Pass,Patrick Kenzie,Pass,Jessie Robinson,",
         "Direction,<<<<<<,",
         "D,Justine Price,",
-        "POINT,Mark Donahue,Pass,Richard Gregory,Pass,Nina Ramic,Pass,chris sullivan(S),Pass,Justine Price,Pass,chris sullivan(S),Pass,Nina Ramic,Pass,Justine Price,Pass,chris sullivan(S),Pass,Richard Gregory,",
+        "POINT,Mark Donahue,Pass,Richard Gregory,Pass,Nina Ramic,Pass,Chris Sullivan,Pass,Justine Price,Pass,Chris Sullivan,Pass,Nina Ramic,Pass,Justine Price,Pass,Chris Sullivan,Pass,Richard Gregory,",
         "-1,Jason Fraser,",
         "-1,Patrick Kenzie,",
         "-1,Trevor Ryan,",
@@ -2987,11 +2987,11 @@
         "+1,Richard Gregory,",
         "+1,Justine Price,",
         "+1,Nina Ramic,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Drop,Ryan Mussell,Pass,Jonathan Pindur,Pass,Megan Robb,Pass,Tanya Gallant,Pass,Kevin Hughes,",
         "Direction,<<<<<<,",
-        "POINT,Rob Ives,Pass,Brent Burton,Pass,chris sullivan(S),Pass,Janet Ibit,Pass,Brent Burton,Pass,chris sullivan(S),",
+        "POINT,Rob Ives,Pass,Brent Burton,Pass,Chris Sullivan,Pass,Janet Ibit,Pass,Brent Burton,Pass,Chris Sullivan,",
         "-1,Kevin Hughes,",
         "-1,Ryan Mussell,",
         "-1,Jonathan Pindur,",
@@ -3003,7 +3003,7 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Megan Robb,Pass,Jessie Robinson,Pass,Patrick Kenzie,Pass,Trevor Ryan,Pass,Patrick Kenzie,Pass,Jessie Robinson,",
         "Direction,<<<<<<,",
@@ -3034,7 +3034,7 @@
         "-1,Mark Donahue,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,chris sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "Throw Away,Richard Gregory,Pass,Martin Cloake,Pass,Ariel Untiveros,Pass,Richard Gregory,Pass,Brent Burton,",
         "Direction,>>>>>>,",
@@ -3055,13 +3055,13 @@
         "Time,Half,",
         "Pull,Ryan Mussell,",
         "Direction,<<<<<<,",
-        "Throw Away,chris sullivan(S),Pass,Rob Ives,",
+        "Throw Away,Chris Sullivan,Pass,Rob Ives,",
         "Direction,>>>>>>,",
         "D,Megan Robb,",
         "Throw Away,Jessie Robinson,Pass,Trevor Stocki,Pass,Kevin Hughes,",
         "Direction,<<<<<<,",
-        "D,chris sullivan(S),",
-        "POINT,chris sullivan(S),Pass,Rob Ives,Pass,Janet Ibit,Pass,chris sullivan(S),",
+        "D,Chris Sullivan,",
+        "POINT,Chris Sullivan,Pass,Rob Ives,Pass,Janet Ibit,Pass,Chris Sullivan,",
         "-1,Kevin Hughes,",
         "-1,Ryan Mussell,",
         "-1,Jonathan Pindur,",
@@ -3073,7 +3073,7 @@
         "+1,Ariel Untiveros,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Drop,Jay Thor Turner,Pass,Trevor Ryan,Pass,Jessie Robinson,Pass,Jay Thor Turner,Pass,Trevor Ryan,Pass,Jessie Robinson,Pass,Tanya Gallant,Pass,Jessie Robinson,",
         "Direction,<<<<<<,",
@@ -3108,7 +3108,7 @@
         "-1,Ariel Untiveros,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,chris sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
         "Throw Away,Ariel Untiveros,Pass,Richard Gregory,Pass,Ariel Untiveros,Pass,Richard Gregory,Pass,Nina Ramic,Pass,Mark Donahue,Pass,Richard Gregory,",
         "Direction,>>>>>>,",
@@ -3131,7 +3131,7 @@
         "Direction,>>>>>>,",
         "Throw Away,Tanya Gallant,Pass,Kevin Hughes,",
         "Direction,<<<<<<,",
-        "Throw Away,chris sullivan(S),Pass,Brent Burton,Pass,Janet Ibit,",
+        "Throw Away,Chris Sullivan,Pass,Brent Burton,Pass,Janet Ibit,",
         "Direction,>>>>>>,",
         "D,Jonathan Pindur,",
         "Throw Away,Jessie Robinson,Pass,Ryan Mussell,Pass,Jessie Robinson,Pass,Trevor Stocki,",
@@ -3154,7 +3154,7 @@
         "+1,Martin Cloake,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Jason Fraser,Pass,Megan Robb,Pass,Patrick Kenzie,Pass,Trevor Ryan,Pass,Patrick Kenzie,",
         "+1,Jason Fraser,",
@@ -3170,7 +3170,7 @@
         "-1,Justine Price,",
         "-1,Nina Ramic,",
         "Direction,<<<<<<,",
-        "POINT,chris sullivan(S),Pass,Martin Cloake,Pass,Richard Gregory,Pass,Hope Celani,Pass,Martin Cloake,Pass,Brent Burton,Pass,Richard Gregory,Pass,Brent Burton,Pass,Richard Gregory,",
+        "POINT,Chris Sullivan,Pass,Martin Cloake,Pass,Richard Gregory,Pass,Hope Celani,Pass,Martin Cloake,Pass,Brent Burton,Pass,Richard Gregory,Pass,Brent Burton,Pass,Richard Gregory,",
         "-1,Kevin Hughes,",
         "-1,Ryan Mussell,",
         "-1,Jonathan Pindur,",
@@ -3182,7 +3182,7 @@
         "+1,Richard Gregory,",
         "+1,Hope Celani,",
         "+1,Janet Ibit,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Patrick Kenzie,Pass,Trevor Ryan,Pass,Jay Thor Turner,Pass,Trevor Ryan,Pass,Patrick Kenzie,Pass,Jessie Robinson,",
         "Direction,<<<<<<,",
@@ -3213,9 +3213,9 @@
         "-1,Richard Gregory,",
         "-1,Hope Celani,",
         "-1,Janet Ibit,",
-        "-1,chris sullivan(S),",
+        "-1,Chris Sullivan,",
         "Direction,<<<<<<,",
-        "POINT,Rob Ives,Pass,Ariel Untiveros,Pass,chris sullivan(S),",
+        "POINT,Rob Ives,Pass,Ariel Untiveros,Pass,Chris Sullivan,",
         "-1,Jason Fraser,",
         "-1,Patrick Kenzie,",
         "-1,Trevor Ryan,",
@@ -3227,7 +3227,7 @@
         "+1,Ariel Untiveros,",
         "+1,Justine Price,",
         "+1,Nina Ramic,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Drop,Jonathan Pindur,Pass,Ryan Mussell,Pass,Kevin Hughes,Pass,Jessie Robinson,Pass,Jonathan Pindur,Pass,Jessie Robinson,",
         "Direction,<<<<<<,",
@@ -3251,7 +3251,7 @@
         "Direction,>>>>>>,",
         "Drop,Megan Robb,Pass,Patrick Kenzie,",
         "Direction,<<<<<<,",
-        "POINT,Richard Gregory,Pass,chris sullivan(S),Pass,Nina Ramic,",
+        "POINT,Richard Gregory,Pass,Chris Sullivan,Pass,Nina Ramic,",
         "-1,Jason Fraser,",
         "-1,Patrick Kenzie,",
         "-1,Trevor Ryan,",
@@ -3263,7 +3263,7 @@
         "+1,Richard Gregory,",
         "+1,Justine Price,",
         "+1,Nina Ramic,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "Throw Away,Jessie Robinson,Pass,Jonathan Pindur,Pass,Kevin Hughes,",
         "Direction,<<<<<<,",
@@ -3308,7 +3308,7 @@
         "Direction,>>>>>>,",
         "Drop,Jay Thor Turner,Pass,Trevor Ryan,Pass,Jessie Robinson,",
         "Direction,<<<<<<,",
-        "POINT,Ariel Untiveros,Pass,Justine Price,Pass,chris sullivan(S),Pass,Richard Gregory,Pass,Nina Ramic,Pass,chris sullivan(S),Pass,Ariel Untiveros,",
+        "POINT,Ariel Untiveros,Pass,Justine Price,Pass,Chris Sullivan,Pass,Richard Gregory,Pass,Nina Ramic,Pass,Chris Sullivan,Pass,Ariel Untiveros,",
         "-1,Jason Fraser,",
         "-1,Patrick Kenzie,",
         "-1,Trevor Ryan,",
@@ -3320,7 +3320,7 @@
         "+1,Ariel Untiveros,",
         "+1,Justine Price,",
         "+1,Nina Ramic,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,",
         "POINT,Megan Robb,Pass,Kevin Hughes,Pass,Ryan Mussell,Pass,Jonathan Pindur,Pass,Ryan Mussell,Pass,Kevin Hughes,Pass,Tanya Gallant,Pass,Kevin Hughes,",
         "+1,Kevin Hughes,",
@@ -3348,7 +3348,7 @@
         "+1,Ariel Untiveros,",
         "+1,Justine Price,",
         "+1,Nina Ramic,",
-        "+1,chris sullivan(S),",
+        "+1,Chris Sullivan,",
         "Direction,>>>>>>,"
     ]
 }

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -3,126 +3,59 @@ let expect = chai.expect
 
 chai.use(require('sinon-chai'))
 
-process.env.MONGODB_URI = 'mongodb://localhost:27017/test'
-const Db = require('monk')(process.env.MONGODB_URI)
-const Games = Db.get('games')
-
 import calcSalaries from '../../lib/calc_salaries'
 
 describe('calcSalaries', function () {
-  it('increase for goals', function () {
-    let stats = {
-      'Mike': {
-        'Goals': 1
+  let stats = {
+    'Mike': {
+      'Goals': 1
+    }
+  }
+
+  let games = [
+    {
+      week: 1,
+      stats: {
+        'Jill': {'Team': 'Katy Parity', 'D': 1, 'SalaryDelta': 5000, 'Salary': 100000},
+        'Mike': {'Team': 'Beans', 'Goals': 1, 'SalaryDelta': 10000, 'Salary': 500000}
       }
     }
-    let salaryDeltas = calcSalaries(stats)
+  ]
+
+  it('increase for goals', function () {
+    let salaryDeltas = calcSalaries(stats, [])
     expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(10000)
   })
 
   it('decrease for drops', function () {
-    let stats = {
-      'Mike': {
-        'Drops': 1
-      }
-    }
-    let salaryDeltas = calcSalaries(stats)
+    stats['Mike'] = { 'Drops': 1 }
+    let salaryDeltas = calcSalaries(stats, [])
     expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(-5000)
   })
 
   it('gives the default for initial salary', function () {
-    let stats = {
-      'Mike': {
-        'Drops': 1
-      }
-    }
-    let salaryDeltas = calcSalaries(stats)
+    stats['Mike'] = { 'Drops': 1 }
+    let salaryDeltas = calcSalaries(stats, [])
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 
-  it('gives previous weeks average salary + gains to a new player in week 2 or higher', function () {
-    let stats = {
-      'Mike': {'Team': 'Beans', 'Goals': 2},
-      'Jill': {'Team': 'Beans', 'Goals': 1}
-    }
-
-    let prevWeek = {
-      week: 2,
-      stats: {'Jill': {'Salary': 100000, 'SalaryDelta': 5000}}
-    }
-
-    let salaryDeltas = calcSalaries(stats, prevWeek)
-    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(20000)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(120000)
-  })
-
-  it('gives previous weeks average salary to a new absent player in week 2 or higher', function () {
-    let stats = {
-      'Mike': {'Team': 'Beans'},
-      'Jill': {'Team': 'Beans', 'Goals': 1}
-    }
-
-    let prevWeek = {
-      week: 2,
-      stats: {'Jill': {'Salary': 100000, 'SalaryDelta': 5000}}
-    }
-
-    let salaryDeltas = calcSalaries(stats, prevWeek)
-    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(10000)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(110000)
-  })
-
-  it('gives the average salary delta to a player who misses week 1', function () {
-    let stats = {
-      'Mike': {'Team': 'Beans'},
-      'Jim': {'Team': 'Beans', 'Goals': 1},
-      'Meg': {'Team': 'Beans', 'D-Blocks': 1}
-    }
-
-    // 1 playValues[Goal] * 1 playValues[D-Block]
-    let expectedDelta = (10000 + 8000) / 2
-
-    // defaultSalary + expectedDelta
-    let expectedSalary = 500000 + expectedDelta
-
-    let salaryDeltas = calcSalaries(stats)
-    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(expectedDelta)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(expectedSalary)
-  })
-
   it('gives a player their average salary delta if they are absent', function () {
-    let stats = {
-      'Mike': {'Team': 'Beans'}
-    }
-
-    let prevWeek = {
-      week: 1,
-      stats: {
-        'Mike': {'Team': 'Beans', 'Goals': 1, 'SalaryDelta': 10000, 'Salary': 500000}
-      }
-    }
-
-    let salaryDeltas = calcSalaries(stats, prevWeek)
+    stats['Mike'] = {'Team': 'Beans'}
+    let salaryDeltas = calcSalaries(stats, games)
     expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(10000)
     expect(salaryDeltas['Mike']['Salary']).to.equal(510000)
   })
 
-  it('adds to previous salary', function () {
-    let stats = {
-      'Mike': {
-        'Drops': 1
-      }
-    }
+  it('averageDelta is 0 for player who has no past games', function () {
+    stats['Mike'] = {'Team': 'Beans'}
+    let salaryDeltas = calcSalaries(stats, [])
+    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(0)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(500000)
+  })
 
-    let prevWeek = {
-      stats: {
-        'Mike': {
-          'Salary': 1000000
-        }
-      }
-    }
-
-    let salaryDeltas = calcSalaries(stats, prevWeek)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(995000)
+  it('adds delta to previous salary', function () {
+    stats['Mike'] = { 'Drops': 1 }
+    let salaryDeltas = calcSalaries(stats, games)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 })

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -46,11 +46,22 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(510000)
   })
 
-  it('averageDelta is 0 for player who has no past games', function () {
-    stats['Mike'] = {'Team': 'Beans'}
+  it('give team average delta if no history is available', function () {
+    stats = {
+      'Mike': {'Team': 'Beans'},
+      'Jim': {'Team': 'Beans', 'Goals': 1},
+      'Meg': {'Team': 'Beans', 'D-Blocks': 1}
+    }
+
+    // 1 playValues[Goal] * 1 playValues[D-Block]
+    let expectedDelta = (10000 + 8000) / 2
+
+    // defaultSalary + expectedDelta
+    let expectedSalary = 500000 + expectedDelta
+
     let salaryDeltas = calcSalaries(stats, [])
-    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(0)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(500000)
+    expect(salaryDeltas['Mike']['SalaryDelta']).to.equal(expectedDelta)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(expectedSalary)
   })
 
   it('adds delta to previous salary', function () {

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -39,6 +39,12 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
   })
 
+  it('adds delta to previous salary', function () {
+    stats['Mike'] = { 'Drops': 1 }
+    let salaryDeltas = calcSalaries(stats, games)
+    expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
+  })
+
   it('gives a player their average salary delta if they are absent', function () {
     stats['Mike'] = {'Team': 'Beans'}
     let salaryDeltas = calcSalaries(stats, games)
@@ -46,7 +52,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(510000)
   })
 
-  it('give team average delta if no history is available', function () {
+  it('gives team average delta if no history is available', function () {
     stats = {
       'Mike': {'Team': 'Beans'},
       'Jim': {'Team': 'Beans', 'Goals': 1},
@@ -64,9 +70,12 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(expectedSalary)
   })
 
-  it('adds delta to previous salary', function () {
-    stats['Mike'] = { 'Drops': 1 }
+  it('gives a new player their delta multplied by the number of weeks into the league', function () {
+    stats = { 'Newbie': {'Team': 'Beans', 'Goals': 1} }
+    games[0].week = 4
+
     let salaryDeltas = calcSalaries(stats, games)
-    expect(salaryDeltas['Mike']['Salary']).to.equal(495000)
+    expect(salaryDeltas['Newbie']['SalaryDelta']).to.equal(10000)
+    expect(salaryDeltas['Newbie']['Salary']).to.equal(540000)
   })
 })

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -3,6 +3,10 @@ let expect = chai.expect
 
 chai.use(require('sinon-chai'))
 
+process.env.MONGODB_URI = 'mongodb://localhost:27017/test'
+const Db = require('monk')(process.env.MONGODB_URI)
+const Games = Db.get('games')
+
 import calcSalaries from '../../lib/calc_salaries'
 
 describe('calcSalaries', function () {
@@ -86,7 +90,7 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(expectedSalary)
   })
 
-  it('gives salary delta from the previous week if player is absent', function () {
+  it('gives a player their average salary delta if they are absent', function () {
     let stats = {
       'Mike': {'Team': 'Beans'}
     }

--- a/test/routes/upload_test.js
+++ b/test/routes/upload_test.js
@@ -139,18 +139,6 @@ describe('POST /upload', function () {
     expect(w2['stats']['Mike']['Salary']).to.equal(522000)
   })
 
-  it('salary adds week to week for Absent Player', async function () {
-    await request.post({url: url, json: true, body: game1})
-    let game = _.assign({}, game1, {week: 2})
-    await request.post({url: url, json: true, body: game})
-
-    let w1 = await request.get(`${baseUrl}/weeks/1`, { json: true })
-    let w2 = await request.get(`${baseUrl}/weeks/2`, { json: true })
-
-    expect(w1['stats']['Absent Player']['Salary']).to.equal(503625)
-    expect(w2['stats']['Absent Player']['Salary']).to.equal(507250)
-  })
-
   // Note that it is a requirement the players are in the roster
   // even if they don't play.
   it('plays week 1, misses week 2, plays week 3', async function () {


### PR DESCRIPTION
Adds code for calculating the average salary delta for a player based on all their games. To do this I am re-working the logic a little bit and the `upload` function starts by querying all games which are passed down through other functions as required. This is a fair amount of data but manageable and we don't need this end point to be fast for any reason.

This also removes all the logic for how to handle new players in subsequent weeks since I've learned this is best done manually (currently I just edit their salary after their first game and bump them by the difference between where we want them to start and the default)