### PR TITLE
Fetch teams cache

### DIFF
--- a/lib/fetch_teams.js
+++ b/lib/fetch_teams.js
@@ -1,0 +1,110 @@
+import _ from 'lodash'
+import request from 'request-promise'
+import cheerio from 'cheerio'
+
+const loginUrl = `http://www.ocua.ca/user/login`
+const baseUrl = 'http://www.ocua.ca/zuluru'
+
+// Parity 2015 / 16
+// const leagueID = 494
+// const leaguePath = `${baseUrl}/leagues/view/league:${leagueID}`
+
+// Parity 2016 / 17
+const leagueID = 940
+const leaguePath = `${baseUrl}/divisions/view/division:${leagueID}`
+
+let fetchTeams = async function () {
+  await loginToZuluru()
+  let teamIds = await fetchTeamIds()
+  // teamIds = ['9261'] for debugging faster
+  let teams = await buildTeams(teamIds)
+  return teams
+}
+
+// send an error if missing creds
+let loginToZuluru = async function () {
+  let loginHtml = await request.get(loginUrl)
+  let $ = cheerio.load(loginHtml)
+  let formId = $('[name=form_build_id]').val()
+
+  if (!(process.env.ZULURU_USER && process.env.ZULURU_PASSWORD)) {
+    throw new Error('Missing Zurluru Credentials')
+  }
+
+  let form = {
+    name: process.env.ZULURU_USER,
+    pass: process.env.ZULURU_PASSWORD,
+    form_build_id: formId,
+    form_id: 'user_login',
+    op: 'log_in'
+  }
+
+  return request.post(loginUrl, {form: form, simple: false, jar: true})
+}
+
+let fetchTeamIds = async function () {
+  let teamsHtml = await request.get(leaguePath, {jar: true})
+  let $ = cheerio.load(teamsHtml)
+
+  let anchorTags = $('tr > td > a.trigger')
+
+  let teamIds = _.map(anchorTags, (tag) => {
+    return tag.attribs.id.replace('teams_team_', '')
+  })
+
+  return teamIds
+}
+
+let buildTeams = async function (teamIds) {
+  let teams = {}
+
+  for (let Id of teamIds) {
+    let teamHtml = await request.get(teamPath(Id), {jar: true})
+    let teamName = nameFromTeamPage(teamHtml)
+
+    let teamRoster = playersFromTeamPage(teamHtml)
+    let malePlayers = playersFromTeamPage(teamHtml, 'Male')
+    let femalePlayers = playersFromTeamPage(teamHtml, 'Female')
+
+    teams[teamName] = {
+      players: teamRoster,
+      malePlayers: malePlayers,
+      femalePlayers: femalePlayers
+    }
+  }
+
+  return teams
+}
+
+let teamPath = function (teamId) {
+  return `${baseUrl}/teams/view/team:${teamId}`
+}
+
+let nameFromTeamPage = function (teamHtml) {
+  let $ = cheerio.load(teamHtml)
+  return $('div.teams > h2').text()
+}
+
+let playersFromTeamPage = function (teamHtml, gender = null) {
+  let $ = cheerio.load(teamHtml)
+
+  let tableRows = $('table.list > tr')
+  tableRows = tableRows.slice(1, tableRows.length - 1)
+
+  // optional gender filter
+  if (gender) {
+    tableRows = _.filter(tableRows, (row) => {
+      let genderCell = $(row).find('td').eq(3)
+      return genderCell.text() === gender
+    })
+  }
+
+  let playerNames = _.map(tableRows, (row) => {
+    let nameCell = $(row).find('td').eq(0).find('a')
+    return nameCell.text()
+  })
+
+  return playerNames
+}
+
+module.exports = fetchTeams

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "mongodb": "^2.2.10",
     "monk": "^3.1.2",
     "morgan": "^1.7.0",
+    "node-cache": "^4.1.0",
     "request": "^2.61.0",
     "request-promise": "^4.1.1"
   },

--- a/routes/teams.js
+++ b/routes/teams.js
@@ -3,20 +3,7 @@
 import express from 'express'
 let router = express.Router()
 
-import _ from 'lodash'
-import request from 'request-promise'
-import cheerio from 'cheerio'
-
-const loginUrl = `http://www.ocua.ca/user/login`
-const baseUrl = 'http://www.ocua.ca/zuluru'
-
-// Parity 2015 / 16
-// const leagueID = 494
-// const leaguePath = `${baseUrl}/leagues/view/league:${leagueID}`
-
-// Parity 2016 / 17
-const leagueID = 940
-const leaguePath = `${baseUrl}/divisions/view/division:${leagueID}`
+import fetchTeams from '../lib/fetch_teams'
 
 /**
  * @api {get} /teams List
@@ -40,97 +27,8 @@ const leaguePath = `${baseUrl}/divisions/view/division:${leagueID}`
  *    }
  */
 router.get('/teams', async function (req, res) {
-  await loginToZuluru()
-  let teamIds = await fetchTeamIds()
-  // teamIds = ['9261'] for debugging faster
-  let teams = await buildTeams(teamIds)
+  let teams = await fetchTeams()
   res.json(teams)
 })
-
-// send an error if missing creds
-let loginToZuluru = async function () {
-  let loginHtml = await request.get(loginUrl)
-  let $ = cheerio.load(loginHtml)
-  let formId = $('[name=form_build_id]').val()
-
-  if (!(process.env.ZULURU_USER && process.env.ZULURU_PASSWORD)) {
-    throw new Error('Missing Zurluru Credentials')
-  }
-
-  let form = {
-    name: process.env.ZULURU_USER,
-    pass: process.env.ZULURU_PASSWORD,
-    form_build_id: formId,
-    form_id: 'user_login',
-    op: 'log_in'
-  }
-
-  return request.post(loginUrl, {form: form, simple: false, jar: true})
-}
-
-let fetchTeamIds = async function () {
-  let teamsHtml = await request.get(leaguePath, {jar: true})
-  let $ = cheerio.load(teamsHtml)
-
-  let anchorTags = $('tr > td > a.trigger')
-
-  let teamIds = _.map(anchorTags, (tag) => {
-    return tag.attribs.id.replace('teams_team_', '')
-  })
-
-  return teamIds
-}
-
-let buildTeams = async function (teamIds) {
-  let teams = {}
-
-  for (let Id of teamIds) {
-    let teamHtml = await request.get(teamPath(Id), {jar: true})
-    let teamName = nameFromTeamPage(teamHtml)
-
-    let teamRoster = playersFromTeamPage(teamHtml)
-    let malePlayers = playersFromTeamPage(teamHtml, 'Male')
-    let femalePlayers = playersFromTeamPage(teamHtml, 'Female')
-
-    teams[teamName] = {
-      players: teamRoster,
-      malePlayers: malePlayers,
-      femalePlayers: femalePlayers
-    }
-  }
-
-  return teams
-}
-
-let teamPath = function (teamId) {
-  return `${baseUrl}/teams/view/team:${teamId}`
-}
-
-let nameFromTeamPage = function (teamHtml) {
-  let $ = cheerio.load(teamHtml)
-  return $('div.teams > h2').text()
-}
-
-let playersFromTeamPage = function (teamHtml, gender = null) {
-  let $ = cheerio.load(teamHtml)
-
-  let tableRows = $('table.list > tr')
-  tableRows = tableRows.slice(1, tableRows.length - 1)
-
-  // optional gender filter
-  if (gender) {
-    tableRows = _.filter(tableRows, (row) => {
-      let genderCell = $(row).find('td').eq(3)
-      return genderCell.text() === gender
-    })
-  }
-
-  let playerNames = _.map(tableRows, (row) => {
-    let nameCell = $(row).find('td').eq(0).find('a')
-    return nameCell.text()
-  })
-
-  return playerNames
-}
 
 module.exports = router


### PR DESCRIPTION
Problem:
------------
Currently to get the latest rosters I scrape Zuluru in real time. This means the request takes a long time and puts a bunch of load on Zuluru. Currently the only consumer is the Android app and its used once to update the rosters each night.

We've had some issues with rosters not being up to date and I wonder if users are not pressing the reload rosters button or are possibly avoiding it because it is slow. A 3rd option is that the update fails silently and speed could also be a factor here.

Additionally it would be preferable to use the latest roster data on the trade dashboard and teams pages so they reflect trades immediately. The current implementation is too slow so support UI and I also feel it isn't responsible to make that many requests to Zuluru.

Solution:
------------
I came up with this idea for a pretty minimal self refreshing cache in node. Essentially its an in process memory cache which expires every 1.5 hours. When the file is included the cache is warmed and then kept fresh using a setInterval every hour.

I tested this locally on my machine and it works pretty nicely.

Afterwards:
------------
* always fetch rosters before starting a new game on the android app. This will remove some code from the android app
* use the latest rosters on the team and trade pages in the web app
* I could also do a diff between last week and current rosters to show the recent trades