### PR TITLE
fix salary of new player added in week 7, didn't play until week 8

### DIFF
--- a/db/week7_game1.json
+++ b/db/week7_game1.json
@@ -3,7 +3,6 @@
     "teams": {
         "Katy Parity": [
             "Kindha Gorman",
-            "Katie Bigras",
             "Wynne Gee",
             "Jessie Robinson",
             "Jeremy Bryan",

--- a/lib/calc_salaries.js
+++ b/lib/calc_salaries.js
@@ -34,6 +34,7 @@ let calcSalaries = function (stats: any, games: Array<any>) {
     let salaryDelta = calcSalaryDelta(playerStats)
 
     // player was absent
+    // this check works unless they played but never touched the disc
     if (salaryDelta === 0) {
       salaryDelta = player.averageDelta
     }

--- a/test/lib/calc_salaries_test.js
+++ b/test/lib/calc_salaries_test.js
@@ -70,12 +70,33 @@ describe('calcSalaries', function () {
     expect(salaryDeltas['Mike']['Salary']).to.equal(expectedSalary)
   })
 
-  it('gives a new player their delta multplied by the number of weeks into the league', function () {
-    stats = { 'Newbie': {'Team': 'Beans', 'Goals': 1} }
+  it('regular salary gain for new player in week 4', function () {
     games[0].week = 4
+    stats = { 'Newbie': {'Team': 'Beans', 'Goals': 1} }
 
     let salaryDeltas = calcSalaries(stats, games)
-    expect(salaryDeltas['Newbie']['SalaryDelta']).to.equal(10000)
-    expect(salaryDeltas['Newbie']['Salary']).to.equal(540000)
+    let expectedDelta = 10000
+    // the delta multplied by the number of weeks into the league
+    let expectedSalary = expectedDelta * 4 + 500000
+
+    expect(salaryDeltas['Newbie']['SalaryDelta']).to.equal(expectedDelta)
+    expect(salaryDeltas['Newbie']['Salary']).to.equal(expectedSalary)
+  })
+
+  it('negative salary gain for new player in week 8', function () {
+    games[0].week = 8
+    stats = { 'Newbie': {'Team': 'Beans',
+      'Catches': 2,
+      'Completions': 1,
+      'Throwaways': 1,
+      'Drops': 2
+    }}
+
+    let salaryDeltas = calcSalaries(stats, games)
+    let expectedDelta = -12000
+    let expectedSalary = expectedDelta * 8 + 500000
+
+    expect(salaryDeltas['Newbie']['SalaryDelta']).to.equal(expectedDelta)
+    expect(salaryDeltas['Newbie']['Salary']).to.equal(expectedSalary)
   })
 })


### PR DESCRIPTION
I wanted to write out this fix as documentation of this issue in case it happens again. The new player was added in week 7 but didn't play. This means that that they were given their teams average salary delta for that game (because they were on the roster). This code was written this way to deal with people who miss week 1.

This salary then got applied to the players history which boosted the salary above what it should be based on the first game actually played.

My fix was to edit the data. It might be possible to guard this with code which I'll look into later.