### PR TITLE
Add new salary to frontend

### DIFF
--- a/client/src/Components/StatsTable/__snapshots__/index.test.js.snap
+++ b/client/src/Components/StatsTable/__snapshots__/index.test.js.snap
@@ -137,11 +137,11 @@ exports[`test StatsTable renders correctly 1`] = `
               </th>
               <th
                 className=""
-                data-title="SalaryDelta"
+                data-title="pay"
                 onClick={[Function anonymous]}
                 style={Object {}}>
                 <span>
-                  SalaryDelta
+                  Pay
                 </span>
               </th>
             </tr>

--- a/client/src/Components/StatsTable/index.js
+++ b/client/src/Components/StatsTable/index.js
@@ -56,16 +56,18 @@ export default class StatsTable extends Component {
     this.columnsMeta = columnsMeta.slice()
 
     if (this.props.week === 0) {
-      this.columns.push('Salary')
+      this.columns.push('salary')
       this.columnsMeta.push({
-        columnName: 'Salary',
+        columnName: 'salary',
+        displayName: 'Salary',
         order: STATS.length + 2,
         customComponent: MoneyCell
       })
     } else {
-      this.columns.push('SalaryDelta')
+      this.columns.push('pay')
       this.columnsMeta.push({
-        columnName: 'SalaryDelta',
+        columnName: 'pay',
+        displayName: 'Pay',
         order: STATS.length + 2,
         customComponent: MoneyCell
       })

--- a/client/src/Stores/Stats.js
+++ b/client/src/Stores/Stats.js
@@ -39,7 +39,7 @@ export default class Stats {
     let players = []
     _.mapKeys(this.data, (playerStats, playerName) => {
       if (playerStats['team'] === team) {
-        players.push({name: playerName, salary: playerStats['Salary']})
+        players.push({name: playerName, salary: playerStats['salary']})
       }
     })
 

--- a/data/test/basic_point.json
+++ b/data/test/basic_point.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "1",
   "homeTeam": "lumleysexuals",

--- a/data/test/callahan.json
+++ b/data/test/callahan.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "1",
   "homeTeam": "Kells Angels Bicycle Club",

--- a/data/test/catch_d.json
+++ b/data/test/catch_d.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "0",
   "homeTeam": "Attack",

--- a/data/test/drop.json
+++ b/data/test/drop.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "1",
   "homeTeam": "Betty White (B-Dub)",

--- a/data/test/half.json
+++ b/data/test/half.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "1",
   "homeTeam": "Nautical Disaster - Man Overboard! (SOS)",

--- a/data/test/mini_game.json
+++ b/data/test/mini_game.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "2",
   "homeTeam": "Kells Angels Bicycle Club",

--- a/data/test/mini_game2.json
+++ b/data/test/mini_game2.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "1",
   "homeTeam": "lumleysexuals",

--- a/data/test/throw_away.json
+++ b/data/test/throw_away.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "1",
   "homeTeam": "Ultra Tide: Don an unsullied hue",

--- a/data/test/turnovers.json
+++ b/data/test/turnovers.json
@@ -1,5 +1,5 @@
 {
-  "week": 0,
+  "week": 1,
   "league": "ocua_17-18",
   "awayScore": "1",
   "homeTeam": "lumleysexuals",

--- a/server/app.py
+++ b/server/app.py
@@ -170,15 +170,14 @@ def create_app():
                     team = game.away_team
 
                 data = player_stats.to_dict()
+                data.update({'team': team})
 
                 if player.name in stats:
-                    x = data
-                    y = stats[player.name]
-                    summed_stats = { k: x.get(k, 0) + y.get(k, 0) for k in set(x) & set(y) }
-                    summed_stats.update({'team': team})
-                    stats[player.name] = summed_stats
+                    existing_data = stats[player.name]
+                    stats_to_sum = data.keys() - ['pay', 'salary', 'salary_per_point']
+                    summed_stats = { s: data.get(s, 0) + existing_data.get(s, 0) for s in stats_to_sum }
+                    stats[player.name].update(summed_stats)
                 else:
-                    data.update({'team': team})
                     stats.update({player.name: data})
 
         # display salary

--- a/server/models.py
+++ b/server/models.py
@@ -137,7 +137,11 @@ class Stats(db.Model):
     def _avg_salary_per_point_based_on_history(self):
         player_stats = Stats.query.filter_by(player_id=self.player_id)
         salaries = [ps.salary_per_point for ps in player_stats]
-        return sum(salaries) / len(salaries)
+
+        if len(salaries) > 0:
+            return sum(salaries) / len(salaries)
+        else:
+            return 0
 
     def to_dict(self):
         return {

--- a/server/models.py
+++ b/server/models.py
@@ -18,6 +18,7 @@ class Player(db.Model):
     def is_male(self):
         return self.gender == 'male'
 
+
 class Game(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     league = db.Column(db.Text)
@@ -78,27 +79,6 @@ class Stats(db.Model):
     d_points_for = db.Column(db.Integer, default=0)
     d_points_against = db.Column(db.Integer, default=0)
 
-    def salary_delta(self):
-        return (self.goals * self.SALARY['goals']
-                + self.assists * self.SALARY['assists'] 
-                + self.second_assists * self.SALARY['second_assists']
-                + self.d_blocks * self.SALARY['d_blocks']
-                + self.completions * self.SALARY['completions']
-                + self.throw_aways * self.SALARY['throw_aways']
-                + self.threw_drops * self.SALARY['threw_drops']
-                + self.catches * self.SALARY['catches']
-                + self.drops * self.SALARY['drops']
-                )
-    
-    def points_played(self):
-        return self.o_points_for + self.o_points_against + self.d_points_for + self.d_points_against
-
-    def salary_delta_per_point(self):
-        if self.points_played() == 0:
-            return 0
-        else:
-            return self.salary_delta() / self.points_played()
-
     def __init__(self, game_id, player_id):
         self.game_id = game_id
         self.player_id = player_id
@@ -122,6 +102,43 @@ class Stats(db.Model):
         value = getattr(self, stat)
         setattr(self, stat, value + 1)
 
+    @property
+    def pay(self):
+        total = 0
+        total += self.goals * self.SALARY['goals']
+        total += self.assists * self.SALARY['assists']
+        total += self.second_assists * self.SALARY['second_assists']
+        total += self.d_blocks * self.SALARY['d_blocks']
+        total += self.completions * self.SALARY['completions']
+        total += self.throw_aways * self.SALARY['throw_aways']
+        total += self.threw_drops * self.SALARY['threw_drops']
+        total += self.catches * self.SALARY['catches']
+        total += self.drops * self.SALARY['drops']
+
+        return total
+
+    @property
+    def salary_per_point(self):
+        if self._points_played == 0:
+            return 0
+        else:
+            return self.pay / self._points_played
+
+    @property
+    def _points_played(self):
+        return self.o_points_for + self.o_points_against + self.d_points_for + self.d_points_against
+
+    @property
+    def salary(self):
+        pro_rated_number_of_points = 15
+        return self._avg_salary_per_point_based_on_history * pro_rated_number_of_points
+
+    @property
+    def _avg_salary_per_point_based_on_history(self):
+        player_stats = Stats.query.filter_by(player_id=self.player_id)
+        salaries = [ps.salary_per_point for ps in player_stats]
+        return sum(salaries) / len(salaries)
+
     def to_dict(self):
         return {
             "goals": self.goals,
@@ -138,5 +155,8 @@ class Stats(db.Model):
             "o_points_for": self.o_points_for,
             "o_points_against": self.o_points_against,
             "d_points_for": self.d_points_for,
-            "d_points_against": self.d_points_against
+            "d_points_against": self.d_points_against,
+            "pay": self.salary_per_point,
+            "salary_per_point": self.salary_per_point,
+            "salary": self.salary
         }

--- a/server/test.py
+++ b/server/test.py
@@ -23,78 +23,23 @@ class Test(TestCase):
 
     def get_normalized_stats(self, player_name):
         player = Player.query.filter_by(name=player_name).first()
-        normalized_stats = {}
+
         if player:
             stats = Stats.query.filter_by(player_id=player.id).first()
-            normalized_stats["goals"] = stats.goals
-            normalized_stats["assists"] = stats.assists
-            normalized_stats["second_assists"] = stats.second_assists
-            normalized_stats["d_blocks"] = stats.d_blocks
-            normalized_stats["completions"] = stats.completions
-            normalized_stats["throw_aways"] = stats.throw_aways
-            normalized_stats["threw_drops"] = stats.threw_drops
-            normalized_stats["catches"] = stats.catches
-            normalized_stats["drops"] = stats.drops
-            normalized_stats["pulls"] = stats.pulls
-            normalized_stats["callahan"] = stats.callahan
-            normalized_stats["o_points_for"] = stats.o_points_for
-            normalized_stats["o_points_against"] = stats.o_points_against
-            normalized_stats["d_points_for"] = stats.d_points_for
-            normalized_stats["d_points_against"] = stats.d_points_against
-            normalized_stats["points_played"] = stats.points_played()
-            normalized_stats["salary_delta"] = stats.salary_delta()
-            normalized_stats["salary_delta_per_point"] = stats.salary_delta_per_point()
+            return stats.to_dict()
         else:
-            normalized_stats["goals"] = 0
-            normalized_stats["assists"] = 0
-            normalized_stats["second_assists"] = 0
-            normalized_stats["d_blocks"] = 0
-            normalized_stats["completions"] = 0
-            normalized_stats["throw_aways"] = 0
-            normalized_stats["threw_drops"] = 0
-            normalized_stats["catches"] = 0
-            normalized_stats["drops"] = 0
-            normalized_stats["pulls"] = 0
-            normalized_stats["callahan"] = 0
-            normalized_stats["o_points_for"] = 0
-            normalized_stats["o_points_against"] = 0
-            normalized_stats["d_points_for"] = 0
-            normalized_stats["d_points_against"] = 0
-            normalized_stats["points_played"] = 0
-            normalized_stats["salary_delta"] = 0
-            normalized_stats["salary_delta_per_point"] = 0
-
-        print(player_name,
-            "g:", normalized_stats["goals"],
-            "a:", normalized_stats["assists"],
-            "2nd:", normalized_stats["second_assists"],
-            "d:", normalized_stats["d_blocks"],
-            "comp:", normalized_stats["completions"],
-            "ta:", normalized_stats["throw_aways"],
-            "td:", normalized_stats["threw_drops"],
-            "catches:", normalized_stats["catches"],
-            "drops", normalized_stats["drops"],
-            "pulls:", normalized_stats["pulls"],
-            "callahan:", normalized_stats["callahan"],
-            "o_points_for:", normalized_stats["o_points_for"],
-            "o_points_against:", normalized_stats["o_points_against"],
-            "d_points_for:", normalized_stats["d_points_for"],
-            "d_points_against:", normalized_stats["d_points_against"],
-            "pp:", normalized_stats["points_played"],
-            "sd:", normalized_stats["salary_delta"],
-            "sdpp:", normalized_stats["salary_delta_per_point"]
-            )
-
-        return normalized_stats
-
+            fake_game_id = 0
+            fake_player_id = 0
+            stats = Stats(fake_game_id, fake_player_id)
+            return stats.to_dict()
 
     def test_basic_point(self):
         with open('data/test/basic_point.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: basic_point.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -143,10 +88,10 @@ class Test(TestCase):
     def test_callahan(self):
         with open('data/test/callahan.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: callahan.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -203,10 +148,10 @@ class Test(TestCase):
     def test_catch_d(self):
         with open('data/test/catch_d.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: catch_d.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -262,10 +207,10 @@ class Test(TestCase):
     def test_drop(self):
         with open('data/test/drop.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: drop.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -324,10 +269,10 @@ class Test(TestCase):
     def test_half(self):
         with open('data/test/half.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: half.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -376,10 +321,10 @@ class Test(TestCase):
     def test_mini_game(self):
         with open('data/test/mini_game.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: mini_game.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -505,10 +450,10 @@ class Test(TestCase):
     def test_mini_game2(self):
         with open('data/test/mini_game2.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: mini_game2.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -557,10 +502,10 @@ class Test(TestCase):
     def test_throw_away(self):
         with open('data/test/throw_away.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: throw_away.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -614,10 +559,10 @@ class Test(TestCase):
     def test_turnovers(self):
         with open('data/test/turnovers.json') as f:
             game_str = f.read()
-        self.client.post('/upload', data=game_str, content_type='application/json')
-        print("-------- Game: turnovers.json")
 
-        game = Game.query.filter_by(week=0).first()
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        game = Game.query.filter_by(week=1).first()
         rosters = json.loads(game.home_roster) + json.loads(game.away_roster)
         for player_name in rosters:
             normalized_stats = self.get_normalized_stats(player_name)
@@ -686,14 +631,6 @@ class Test(TestCase):
                 assert normalized_stats["o_points_against"] == 1
             else:
                 assert normalized_stats["o_points_against"] == 0
-
-    # def test_stats_calculator(self):
-    #     game = json.loads(open('data/ocua_17-18_test.json').read())
-    #     points = json.loads(game['points'])['points']
-    #     game_id = 1
-    #
-    #     stats = StatsCalculator(game_id, points).run()
-    #     # assert
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
closes #98 

![image](https://user-images.githubusercontent.com/1965489/32411043-3da593fa-c1a7-11e7-8da9-5d832b9c2566.png)

I finished connecting @wingleungchan's salary calculation to the frontend. To do so I had to serialize these calculations in the `to_dict` method on `Stats`. I decorated these functions with `@property` so they can be called without parenthesis. I also renamed them a bit - I now refer to the raw multiplication of a players stats with the stats values as their `pay`, then I calculate `salary_per_point` for that week. The actual `salary` is calculated by loading all the past `Stats` for the player and averaging their `salary_per_point` and multiplying it by 15 points to standardise salaries around play time.

I extracted a method to build the stats response for all weeks or a given week. I noticed a bug while doing this - the all weeks endpoint wasn't actually summing the stats properly so I fixed it. Inside this method is where I put the logic to pad the salaries to ensure they don't go below 0. This kind of keeps the functional calculation separate from how it is finally displayed which is nice.

We lean on the database pretty heavily to help do these calculations and grab whatever data we need on demand. I figure if it ever gets slow (maybe in later weeks) we can start caching the stats responses since they don't change often.

cc @patrickkenzie @keatesc