### PR TITLE
add forum and podcast links

### DIFF
--- a/client/src/Components/SideNav.js
+++ b/client/src/Components/SideNav.js
@@ -3,6 +3,8 @@ import { Link } from 'react-router'
 
 class SideNav extends Component {
   render () {
+    let forumUrl = 'https://www.ocua.ca/forum/33'
+    let podcastUrl = 'https://soundcloud.com/user-640277634/sets/parity-podcast-season-2/s-Hka7a'
     let spreadsheetUrl = 'https://docs.google.com/spreadsheets/d/1efPmmiEBjpAcVpSFlicd7b5b-1kDzBSPsAhebpupo7I/edit?usp=sharing'
     let srcUrl = 'https://github.com/kevinhughes27/parity-server'
 
@@ -22,6 +24,8 @@ class SideNav extends Component {
 
         <li><div className='divider'></div></li>
 
+        <li><a href={forumUrl} target='_blank'>Forum</a></li>
+        <li><a href={podcastUrl} target='_blank'>Podcast</a></li>
         <li><a href={spreadsheetUrl} target='_blank'>Spreadsheets</a></li>
         <li><a href={srcUrl} target='_blank'>Source Code</a></li>
       </div>

--- a/client/src/Components/__snapshots__/App.test.js.snap
+++ b/client/src/Components/__snapshots__/App.test.js.snap
@@ -80,6 +80,20 @@ exports[`test App renders correctly 1`] = `
           </li>
           <li>
             <a
+              href="https://www.ocua.ca/forum/33"
+              target="_blank">
+              Forum
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://soundcloud.com/user-640277634/sets/parity-podcast-season-2/s-Hka7a"
+              target="_blank">
+              Podcast
+            </a>
+          </li>
+          <li>
+            <a
               href="https://docs.google.com/spreadsheets/d/1efPmmiEBjpAcVpSFlicd7b5b-1kDzBSPsAhebpupo7I/edit?usp=sharing"
               target="_blank">
               Spreadsheets


### PR DESCRIPTION
It would be sweet to link to the podcast and forum to make sure everyone remembers to check these places for new content.

![image](https://user-images.githubusercontent.com/1965489/32411190-62f92848-c1ab-11e7-8f74-df27bf48becd.png)

cc @geofford @keatesc

