### PR TITLE
add backup script and backup week 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ To create the database run `heroku run python server/init_db.py`
 To sync teams from Zuluru run `heroku run python server/zuluru_sync.py`
 
 
+To backup the database (only the raw games data the rest is calculated by the app) run `python server/backup.py`
+
+
 Contributing
 ------------
 

--- a/data/ocua_17-18/week1_game1.json
+++ b/data/ocua_17-18/week1_game1.json
@@ -1,74 +1,79 @@
 {
-  "score": {
-    "home_team": 17,
-    "away_team": 19
-  },
-  "week": 1,
+  "awayRoster": [
+    "Hannah Dawson",
+    "Marie-Ange Gravel",
+    "Katherine Matheson",
+    "Carrie-Anne Whyte",
+    "Brian Kells",
+    "Nick Amlin",
+    "Martin Cloake",
+    "Ben Curran",
+    "Tim Kealey",
+    "Andrew Spearin",
+    "Jamie Wildgen"
+  ],
+  "awayTeam": "Stack Over Flow",
+  "homeTeam": "Huck and Hope Handler Academy (Hope)",
+  "awayScore": 19,
+  "league": "ocua_17-18",
+  "homeScore": 17,
   "points": [
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Brian Perry",
-        "Rob Tyson",
-        "Michael Wong",
-        "Vanessa Mann",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:07:09 PM",
           "firstActor": "Brian Kells",
-          "type": "PULL",
-          "timestamp": "Nov 6, 2017 7:07:09 PM"
+          "type": "PULL"
         },
         {
+          "timestamp": "Nov 6, 2017 7:07:59 PM",
           "firstActor": "Rob Tyson",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 7:07:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:01 PM",
           "firstActor": "Angela Mueller",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:08:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:07 PM",
           "firstActor": "Michael Wong",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:08:07 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:24 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:08:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:26 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:08:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:31 PM",
           "firstActor": "Tim Kealey",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:08:31 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:34 PM",
           "firstActor": "Brian Perry",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:08:34 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:39 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:08:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:08:40 PM",
           "firstActor": "Michael Wong",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:08:40 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -78,58 +83,58 @@
         "Tim Kealey",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Angela Mueller"
       ]
     },
     {
-      "offensePlayers": [
-        "Martin Cloake",
-        "Tim Kealey",
-        "Andrew Spearin",
-        "Jamie Wildgen",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:09:34 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:09:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:09:37 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:09:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:09:40 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 7:09:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:09:43 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:09:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:09:44 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:09:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:09:48 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:09:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:09:50 PM",
           "firstActor": "Martin Cloake",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:09:50 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -139,51 +144,51 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Vanessa Mann"
+      ],
+      "offensePlayers": [
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Kevin Barford",
-        "Brian Perry",
-        "Rob Tyson",
-        "Michael Wong",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:10:53 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:10:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:11:05 PM",
           "firstActor": "Brian Perry",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:11:05 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:11:08 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:11:08 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:11:08 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:11:08 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:11:12 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:11:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:11:13 PM",
           "firstActor": "Ben Curran",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:11:13 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -193,39 +198,39 @@
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Kevin Barford",
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Kristie Ellis",
+        "Angela Mueller"
       ]
     },
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Patrick Kenzie",
-        "Michael Wong",
-        "Kevin Hughes(S)",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:12:14 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Vanessa Mann",
-          "timestamp": "Nov 6, 2017 7:12:14 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:12:15 PM",
           "firstActor": "Vanessa Mann",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:12:15 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 7:12:22 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 7:12:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:12:23 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:12:23 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -235,91 +240,91 @@
         "Andrew Spearin",
         "Marie-Ange Gravel",
         "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Patrick Kenzie",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Vanessa Mann",
+        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Kevin Barford",
-        "Brian Perry",
-        "Rob Tyson",
-        "Kevin Hughes(S)",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:13:12 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:13:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:17 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Rob Tyson",
-          "timestamp": "Nov 6, 2017 7:13:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:24 PM",
           "firstActor": "Rob Tyson",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:13:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:27 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:13:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:31 PM",
           "firstActor": "Brian Perry",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:13:31 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:50 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:13:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:51 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:13:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:56 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Nick Amlin",
-          "timestamp": "Nov 6, 2017 7:13:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:13:58 PM",
           "firstActor": "Nick Amlin",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:13:58 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:14:01 PM",
           "firstActor": "Brian Perry",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:14:01 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:14:07 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:14:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:14:12 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:14:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:14:13 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:14:13 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -329,91 +334,91 @@
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Kevin Barford",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Nick Amlin",
-        "Tim Kealey",
-        "Andrew Spearin",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:14:58 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:14:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:02 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:15:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:05 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:15:05 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:09 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 7:15:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:13 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:15:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:13 PM",
           "firstActor": "Andrew Spearin",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:15:13 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:19 PM",
           "firstActor": "Christopher Keates",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:15:19 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:42 PM",
           "firstActor": "Brian Kells",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:15:42 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:47 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:15:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:49 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:15:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:15:54 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:15:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:16:04 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:16:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:16:08 PM",
           "firstActor": "Kevin Barford",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:16:08 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -423,190 +428,190 @@
         "Michael Wong",
         "Vanessa Mann",
         "Andrea Proulx"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Martin Cloake",
-        "Ben Curran",
-        "Andrew Spearin",
-        "Jamie Wildgen",
-        "Hannah Dawson",
-        "Carrie-Anne Whyte"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:16:42 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:16:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:16:45 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:16:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:16:49 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:16:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:16:53 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:16:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:16:55 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:16:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:16:57 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:16:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:00 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:17:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:07 PM",
           "firstActor": "Martin Cloake",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:17:07 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:11 PM",
           "firstActor": "Rob Tyson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:17:11 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:17 PM",
           "firstActor": "Rob Tyson",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:17:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:18 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 7:17:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:19 PM",
           "firstActor": "Angela Mueller",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:17:19 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:21 PM",
           "firstActor": "Martin Cloake",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:17:21 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:26 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:17:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:28 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:17:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:32 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:17:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:35 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:17:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:38 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:17:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:43 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:17:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:46 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:17:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:48 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:17:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:50 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:17:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:17:53 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:17:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:18:16 PM",
           "firstActor": "Andrew Spearin",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:18:16 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:18:19 PM",
           "firstActor": "Rob Tyson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:18:19 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:18:23 PM",
           "firstActor": "Rob Tyson",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:18:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:18:25 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:18:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:18:27 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:18:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:18:30 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 7:18:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:18:31 PM",
           "firstActor": "Angela Mueller",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:18:31 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -616,52 +621,52 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Martin Cloake",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Nick Amlin",
-        "Tim Kealey",
-        "Andrew Spearin",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:19:20 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Nick Amlin",
-          "timestamp": "Nov 6, 2017 7:19:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:19:24 PM",
           "firstActor": "Nick Amlin",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:19:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:19:28 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 7:19:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:19:31 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:19:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:19:38 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Katherine Matheson",
-          "timestamp": "Nov 6, 2017 7:19:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:19:39 PM",
           "firstActor": "Katherine Matheson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:19:39 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -671,95 +676,95 @@
         "Michael Wong",
         "Vanessa Mann",
         "Andrea Proulx"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Kevin Barford",
-        "Patrick Kenzie",
-        "Rob Tyson",
-        "Kevin Hughes(S)",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:20:19 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:20:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:22 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:20:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:24 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 7:20:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:28 PM",
           "firstActor": "Angela Mueller",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:20:28 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:41 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:20:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:45 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:20:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:49 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:20:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:52 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:20:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:20:54 PM",
           "firstActor": "Ben Curran",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:20:54 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:21:04 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:21:04 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:21:32 PM",
           "firstActor": "Hannah Dawson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:21:32 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:21:34 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:21:34 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:21:39 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:21:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:21:40 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:21:40 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -769,90 +774,90 @@
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Nick Amlin",
-        "Ben Curran",
-        "Andrew Spearin",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:22:17 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:22:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:21 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:22:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:27 PM",
           "firstActor": "Brian Kells",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:22:27 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:29 PM",
           "firstActor": "Kevin Barford",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:22:29 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:43 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:22:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:49 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:22:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:53 PM",
           "firstActor": "Andrea Proulx",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:22:53 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:55 PM",
           "firstActor": "Andrew Spearin",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:22:55 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:22:57 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:22:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:23:00 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:23:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:23:04 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Nick Amlin",
-          "timestamp": "Nov 6, 2017 7:23:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:23:10 PM",
           "firstActor": "Nick Amlin",
-          "type": "PASS",
           "secondActor": "Katherine Matheson",
-          "timestamp": "Nov 6, 2017 7:23:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:23:12 PM",
           "firstActor": "Katherine Matheson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:23:12 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -862,75 +867,75 @@
         "Michael Wong",
         "Vanessa Mann",
         "Andrea Proulx"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Patrick Kenzie",
-        "Rob Tyson",
-        "Kevin Hughes(S)",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:23:56 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 7:23:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:02 PM",
           "firstActor": "Angela Mueller",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:24:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:02 PM",
           "firstActor": "Christopher Keates",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:24:02 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:10 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:24:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:15 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:24:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:20 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:24:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:28 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:24:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:29 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:24:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:32 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:24:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:24:33 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:24:33 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -940,70 +945,70 @@
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
       ]
     },
     {
-      "offensePlayers": [
-        "Kevin Barford",
-        "Patrick Kenzie",
-        "Brian Perry",
-        "Michael Wong",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:25:17 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:25:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:21 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:25:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:25 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:25:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:27 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:25:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:32 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:25:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:37 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:25:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:38 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:25:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:44 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:25:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:25:45 PM",
           "firstActor": "Michael Wong",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:25:45 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1013,156 +1018,156 @@
         "Andrew Spearin",
         "Marie-Ange Gravel",
         "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Martin Cloake",
-        "Andrew Spearin",
-        "Jamie Wildgen",
-        "Hannah Dawson",
-        "Carrie-Anne Whyte"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:26:25 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:26:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:29 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:26:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:30 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:26:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:35 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:26:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:39 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:26:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:42 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:26:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:46 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:26:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:50 PM",
           "firstActor": "Brian Kells",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:26:50 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:53 PM",
           "firstActor": "Christopher Keates",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:26:53 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:26:57 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:26:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:00 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:27:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:04 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:27:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:10 PM",
           "firstActor": "Kristie Ellis",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:27:10 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:16 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:27:16 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:17 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:27:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:18 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:27:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:22 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:27:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:25 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:27:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:29 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:27:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:31 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:27:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:36 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:27:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:38 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:27:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:40 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:27:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:27:42 PM",
           "firstActor": "Hannah Dawson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:27:42 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1172,70 +1177,70 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
       ]
     },
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Patrick Kenzie",
-        "Brian Perry",
-        "Michael Wong",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:28:39 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:28:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:40 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:28:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:41 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:28:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:42 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:28:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:43 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:28:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:44 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:28:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:46 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:28:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:53 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:28:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:28:54 PM",
           "firstActor": "Christopher Keates",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:28:54 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1245,137 +1250,137 @@
         "Tim Kealey",
         "Marie-Ange Gravel",
         "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Martin Cloake",
-        "Tim Kealey",
-        "Andrew Spearin",
-        "Jamie Wildgen",
-        "Hannah Dawson",
-        "Carrie-Anne Whyte"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:29:42 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:29:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:29:46 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:29:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:29:48 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:29:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:29:51 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:29:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:10 PM",
           "firstActor": "Hannah Dawson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:30:10 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:14 PM",
           "firstActor": "Angela Mueller",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:30:14 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:17 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:30:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:19 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:30:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:22 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Rob Tyson",
-          "timestamp": "Nov 6, 2017 7:30:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:24 PM",
           "firstActor": "Rob Tyson",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:30:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:26 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:30:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:37 PM",
           "firstActor": "Kristie Ellis",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:30:37 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:39 PM",
           "firstActor": "Martin Cloake",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:30:39 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:48 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:30:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:53 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:30:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:30:59 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:30:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:31:02 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:31:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:31:04 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:31:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:31:18 PM",
           "firstActor": "Martin Cloake",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:31:18 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:31:29 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:31:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:31:30 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:31:30 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1385,40 +1390,40 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Nick Amlin",
-        "Martin Cloake",
-        "Ben Curran",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:32:14 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:32:14 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:32:23 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:32:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:32:34 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:32:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:32:41 PM",
           "firstActor": "Martin Cloake",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:32:41 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1428,86 +1433,86 @@
         "Michael Wong",
         "Vanessa Mann",
         "Andrea Proulx"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Patrick Kenzie",
-        "Brian Perry",
-        "Rob Tyson",
-        "Kevin Hughes(S)",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:33:26 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:33:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:28 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:33:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:31 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Rob Tyson",
-          "timestamp": "Nov 6, 2017 7:33:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:36 PM",
           "firstActor": "Rob Tyson",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:33:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:41 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:33:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:46 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:33:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:51 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:33:51 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:56 PM",
           "firstActor": "Hannah Dawson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:33:56 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:33:58 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:33:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:34:01 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:34:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:34:10 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:34:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:34:11 PM",
           "firstActor": "Hannah Dawson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:34:11 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1517,262 +1522,262 @@
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
-      ]
-    },
-    {
+      ],
       "offensePlayers": [
-        "Christopher Keates",
-        "Kevin Barford",
-        "Brian Perry",
-        "Michael Wong",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:35:01 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx",
-          "type": "PASS",
-          "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:35:05 PM"
-        },
-        {
-          "firstActor": "Michael Wong",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:35:06 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:36:44 PM"
-        },
-        {
-          "firstActor": "Martin Cloake",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:36:46 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Nick Amlin",
-        "Martin Cloake",
-        "Ben Curran",
-        "Tim Kealey",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Kevin Barford",
-        "Brian Perry",
-        "Michael Wong",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:35:01 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx",
-          "type": "PASS",
-          "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:35:05 PM"
-        },
-        {
-          "firstActor": "Michael Wong",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:35:06 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:36:44 PM"
-        },
-        {
-          "firstActor": "Martin Cloake",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:36:46 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Nick Amlin",
-        "Martin Cloake",
-        "Ben Curran",
-        "Tim Kealey",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kevin Barford",
         "Patrick Kenzie",
-        "Michael Wong",
+        "Brian Perry",
+        "Rob Tyson",
         "Kevin Hughes(S)",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:35:01 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Andrea Proulx",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:35:05 PM",
+          "firstActor": "Andrea Proulx",
+          "secondActor": "Michael Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:35:06 PM",
+          "firstActor": "Michael Wong",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:36:44 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Martin Cloake",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:36:46 PM",
+          "firstActor": "Martin Cloake",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 7:35:01 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Andrea Proulx",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:35:05 PM",
+          "firstActor": "Andrea Proulx",
+          "secondActor": "Michael Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:35:06 PM",
+          "firstActor": "Michael Wong",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:36:44 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Martin Cloake",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:36:46 PM",
+          "firstActor": "Martin Cloake",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 7:37:24 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:37:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:37:31 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:37:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:37:33 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:37:33 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:37:42 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:37:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:37:43 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:37:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:37:43 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:37:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:37:48 PM",
           "firstActor": "Andrew Spearin",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:37:48 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:37:50 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:37:50 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:24 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Rob Tyson",
-          "timestamp": "Nov 6, 2017 7:38:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:25 PM",
           "firstActor": "Rob Tyson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:38:25 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:30 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:38:30 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:48 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:38:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:49 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:38:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:50 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:38:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:51 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:38:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:38:53 PM",
           "firstActor": "Hannah Dawson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:38:53 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:21 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:39:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:25 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:39:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:30 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 7:39:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:33 PM",
           "firstActor": "Angela Mueller",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:39:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:35 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:39:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:40 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 7:39:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:44 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:39:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:46 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 7:39:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:52 PM",
           "firstActor": "Angela Mueller",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:39:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:39:53 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:39:53 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1782,69 +1787,69 @@
         "Jamie Wildgen",
         "Marie-Ange Gravel",
         "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Vanessa Mann",
+        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Nick Amlin",
-        "Martin Cloake",
-        "Tim Kealey",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:40:33 PM",
           "firstActor": "Brian Kells",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:40:33 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:40:40 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:40:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:40:44 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:40:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:40:47 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:40:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:40:49 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Rob Tyson",
-          "timestamp": "Nov 6, 2017 7:40:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:40:53 PM",
           "firstActor": "Rob Tyson",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:40:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:40:58 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Vanessa Mann",
-          "timestamp": "Nov 6, 2017 7:40:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:41:03 PM",
           "firstActor": "Vanessa Mann",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:41:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:41:04 PM",
           "firstActor": "Andrea Proulx",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:41:04 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1854,149 +1859,8 @@
         "Michael Wong",
         "Vanessa Mann",
         "Andrea Proulx"
-      ]
-    },
-    {
+      ],
       "offensePlayers": [
-        "Ben Curran",
-        "Tim Kealey",
-        "Andrew Spearin",
-        "Jamie Wildgen",
-        "Hannah Dawson",
-        "Carrie-Anne Whyte"
-      ],
-      "events": [
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:41:54 PM"
-        },
-        {
-          "firstActor": "Jamie Wildgen",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:41:57 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:42:01 PM"
-        },
-        {
-          "firstActor": "Jamie Wildgen",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:42:07 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:42:10 PM"
-        },
-        {
-          "firstActor": "Carrie-Anne Whyte",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:42:11 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Christopher Keates",
-        "Kevin Barford",
-        "Brian Perry",
-        "Kevin Hughes(S)",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Brian Perry",
-        "Rob Tyson",
-        "Michael Wong",
-        "Kevin Hughes(S)",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:42:58 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes(S)",
-          "type": "PASS",
-          "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:43:02 PM"
-        },
-        {
-          "firstActor": "Michael Wong",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:43:05 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:43:10 PM"
-        },
-        {
-          "firstActor": "Brian Kells",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:43:26 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 7:43:29 PM"
-        },
-        {
-          "firstActor": "Marie-Ange Gravel",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:43:30 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes(S)",
-          "type": "PASS",
-          "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:43:40 PM"
-        },
-        {
-          "firstActor": "Michael Wong",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:43:45 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:43:46 PM"
-        },
-        {
-          "firstActor": "Brian Kells",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:44:02 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:44:06 PM"
-        },
-        {
-          "firstActor": "Martin Cloake",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:44:11 PM"
-        }
-      ],
-      "defensePlayers": [
         "Brian Kells",
         "Nick Amlin",
         "Martin Cloake",
@@ -2006,165 +1870,306 @@
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 7:41:54 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Jamie Wildgen",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:41:57 PM",
+          "firstActor": "Jamie Wildgen",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:42:01 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Jamie Wildgen",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:42:07 PM",
+          "firstActor": "Jamie Wildgen",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:42:10 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Carrie-Anne Whyte",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:42:11 PM",
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
       "offensePlayers": [
-        "Nick Amlin",
         "Ben Curran",
+        "Tim Kealey",
         "Andrew Spearin",
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
-      ],
+      ]
+    },
+    {
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:42:58 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Kevin Hughes(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:02 PM",
+          "firstActor": "Kevin Hughes(S)",
+          "secondActor": "Michael Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:05 PM",
+          "firstActor": "Michael Wong",
+          "secondActor": "Andrea Proulx",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:10 PM",
+          "firstActor": "Andrea Proulx",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:26 PM",
+          "firstActor": "Brian Kells",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:29 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Marie-Ange Gravel",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:30 PM",
+          "firstActor": "Marie-Ange Gravel",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:40 PM",
+          "firstActor": "Kevin Hughes(S)",
+          "secondActor": "Michael Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:45 PM",
+          "firstActor": "Michael Wong",
+          "secondActor": "Andrea Proulx",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:43:46 PM",
+          "firstActor": "Andrea Proulx",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:44:02 PM",
+          "firstActor": "Brian Kells",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:44:06 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Martin Cloake",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:44:11 PM",
+          "firstActor": "Martin Cloake",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Martin Cloake",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 7:49:22 PM",
           "firstActor": "Christopher Keates",
-          "type": "PULL",
-          "timestamp": "Nov 6, 2017 7:49:22 PM"
+          "type": "PULL"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:23 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:50:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:26 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:50:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:29 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:50:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:32 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:50:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:35 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:50:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:37 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:50:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:39 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:50:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:42 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:50:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:45 PM",
           "firstActor": "Andrew Spearin",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:50:45 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:47 PM",
           "firstActor": "Michael Wong",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:50:47 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:48 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:50:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:50:57 PM",
           "firstActor": "Christopher Keates",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:50:57 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:12 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:51:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:17 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:51:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:23 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:51:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:27 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:51:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:29 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:51:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:33 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:51:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:38 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:51:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:44 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:51:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:50 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:51:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:53 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Nick Amlin",
-          "timestamp": "Nov 6, 2017 7:51:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:51:56 PM",
           "firstActor": "Nick Amlin",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:51:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:52:00 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:52:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:52:01 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:52:01 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2174,63 +2179,63 @@
         "Michael Wong",
         "Vanessa Mann",
         "Andrea Proulx"
+      ],
+      "offensePlayers": [
+        "Nick Amlin",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
       ]
     },
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Brian Perry",
-        "Rob Tyson",
-        "Kevin Hughes(S)",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:52:49 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 7:52:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:52:52 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 7:52:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:52:56 PM",
           "firstActor": "Christopher Keates",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:52:56 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 7:53:24 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:53:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:53:31 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 7:53:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:53:41 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:53:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:53:48 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:53:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 7:53:49 PM",
           "firstActor": "Ben Curran",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:53:49 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2240,294 +2245,8 @@
         "Tim Kealey",
         "Marie-Ange Gravel",
         "Katherine Matheson"
-      ]
-    },
-    {
+      ],
       "offensePlayers": [
-        "Kevin Barford",
-        "Patrick Kenzie",
-        "Brian Perry",
-        "Michael Wong",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:54:26 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx",
-          "type": "PASS",
-          "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:54:31 PM"
-        },
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 7:54:39 PM"
-        },
-        {
-          "firstActor": "Patrick Kenzie",
-          "type": "PASS",
-          "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 7:54:47 PM"
-        },
-        {
-          "firstActor": "Michael Wong",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:54:49 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx",
-          "type": "PASS",
-          "secondActor": "Vanessa Mann",
-          "timestamp": "Nov 6, 2017 7:54:57 PM"
-        },
-        {
-          "firstActor": "Vanessa Mann",
-          "type": "PASS",
-          "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:54:59 PM"
-        },
-        {
-          "firstActor": "Kevin Barford",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:55:00 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:55:18 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 7:55:20 PM"
-        },
-        {
-          "firstActor": "Jamie Wildgen",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:55:23 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Nick Amlin",
-          "timestamp": "Nov 6, 2017 7:55:30 PM"
-        },
-        {
-          "firstActor": "Nick Amlin",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:55:34 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:55:38 PM"
-        },
-        {
-          "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:55:41 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:55:44 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:55:48 PM"
-        },
-        {
-          "firstActor": "Hannah Dawson",
-          "type": "PASS",
-          "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:55:50 PM"
-        },
-        {
-          "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:55:53 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:55:55 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:56:00 PM"
-        },
-        {
-          "firstActor": "Brian Perry",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:56:01 PM"
-        },
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:56:04 PM"
-        },
-        {
-          "firstActor": "Kevin Barford",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:56:07 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:56:28 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:56:34 PM"
-        },
-        {
-          "firstActor": "Hannah Dawson",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:56:37 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:56:39 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 7:56:44 PM"
-        },
-        {
-          "firstActor": "Carrie-Anne Whyte",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:56:48 PM"
-        },
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 7:57:21 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 7:57:23 PM"
-        },
-        {
-          "firstActor": "Hannah Dawson",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:57:34 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 7:57:37 PM"
-        },
-        {
-          "firstActor": "Hannah Dawson",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 7:57:40 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 7:57:45 PM"
-        },
-        {
-          "firstActor": "Kevin Barford",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 7:57:51 PM"
-        },
-        {
-          "firstActor": "Patrick Kenzie",
-          "type": "PASS",
-          "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 7:57:53 PM"
-        },
-        {
-          "firstActor": "Brian Perry",
-          "type": "PASS",
-          "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 7:57:59 PM"
-        },
-        {
-          "firstActor": "Kevin Barford",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:58:00 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Nick Amlin",
-        "Tim Kealey",
-        "Andrew Spearin",
-        "Jamie Wildgen",
-        "Hannah Dawson",
-        "Carrie-Anne Whyte"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Brian Kells",
-        "Martin Cloake",
-        "Ben Curran",
-        "Andrew Spearin",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Kells",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 7:58:53 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 7:59:00 PM"
-        },
-        {
-          "firstActor": "Martin Cloake",
-          "type": "PASS",
-          "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 7:59:51 PM"
-        },
-        {
-          "firstActor": "Ben Curran",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 7:59:52 PM"
-        }
-      ],
-      "defensePlayers": [
         "Christopher Keates",
         "Brian Perry",
         "Rob Tyson",
@@ -2537,6 +2256,247 @@
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 7:54:26 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Andrea Proulx",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:54:31 PM",
+          "firstActor": "Andrea Proulx",
+          "secondActor": "Brian Perry",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:54:39 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Patrick Kenzie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:54:47 PM",
+          "firstActor": "Patrick Kenzie",
+          "secondActor": "Michael Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:54:49 PM",
+          "firstActor": "Michael Wong",
+          "secondActor": "Andrea Proulx",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:54:57 PM",
+          "firstActor": "Andrea Proulx",
+          "secondActor": "Vanessa Mann",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:54:59 PM",
+          "firstActor": "Vanessa Mann",
+          "secondActor": "Kevin Barford",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:00 PM",
+          "firstActor": "Kevin Barford",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:18 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:20 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Jamie Wildgen",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:23 PM",
+          "firstActor": "Jamie Wildgen",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:30 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Nick Amlin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:34 PM",
+          "firstActor": "Nick Amlin",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:38 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Carrie-Anne Whyte",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:41 PM",
+          "firstActor": "Carrie-Anne Whyte",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:44 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:48 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Hannah Dawson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:50 PM",
+          "firstActor": "Hannah Dawson",
+          "secondActor": "Carrie-Anne Whyte",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:53 PM",
+          "firstActor": "Carrie-Anne Whyte",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:55:55 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:00 PM",
+          "firstActor": "Andrew Spearin",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:01 PM",
+          "firstActor": "Brian Perry",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:04 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Kevin Barford",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:07 PM",
+          "firstActor": "Kevin Barford",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:28 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:34 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Hannah Dawson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:37 PM",
+          "firstActor": "Hannah Dawson",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:39 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:44 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Carrie-Anne Whyte",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:56:48 PM",
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:21 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Andrea Proulx",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:23 PM",
+          "firstActor": "Andrea Proulx",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:34 PM",
+          "firstActor": "Hannah Dawson",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:37 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Hannah Dawson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:40 PM",
+          "firstActor": "Hannah Dawson",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:45 PM",
+          "firstActor": "Tim Kealey",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:51 PM",
+          "firstActor": "Kevin Barford",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:53 PM",
+          "firstActor": "Patrick Kenzie",
+          "secondActor": "Brian Perry",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:57:59 PM",
+          "firstActor": "Brian Perry",
+          "secondActor": "Kevin Barford",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:58:00 PM",
+          "firstActor": "Kevin Barford",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
       "offensePlayers": [
         "Kevin Barford",
         "Patrick Kenzie",
@@ -2544,60 +2504,105 @@
         "Michael Wong",
         "Vanessa Mann",
         "Andrea Proulx"
-      ],
+      ]
+    },
+    {
       "events": [
         {
+          "timestamp": "Nov 6, 2017 7:58:53 PM",
+          "firstActor": "Brian Kells",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:59:00 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Martin Cloake",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:59:51 PM",
+          "firstActor": "Martin Cloake",
+          "secondActor": "Ben Curran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 7:59:52 PM",
+          "firstActor": "Ben Curran",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:00:32 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Vanessa Mann",
-          "timestamp": "Nov 6, 2017 8:00:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:00:34 PM",
           "firstActor": "Vanessa Mann",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 8:00:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:00:40 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 8:00:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:00:46 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 8:00:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:00:49 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 8:00:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:00:51 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 8:00:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:00:56 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 8:00:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:01:00 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 8:01:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:01:01 PM",
           "firstActor": "Brian Perry",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:01:01 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2607,153 +2612,153 @@
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Martin Cloake",
-        "Ben Curran",
-        "Andrew Spearin",
-        "Jamie Wildgen",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:02:04 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 8:02:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:09 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:02:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:15 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Katherine Matheson",
-          "timestamp": "Nov 6, 2017 8:02:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:16 PM",
           "firstActor": "Katherine Matheson",
-          "type": "PASS",
           "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 8:02:16 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:18 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 8:02:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:21 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 8:02:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:26 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:02:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:34 PM",
           "firstActor": "Andrew Spearin",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:02:34 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:36 PM",
           "firstActor": "Kristie Ellis",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:02:36 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:50 PM",
           "firstActor": "Kristie Ellis",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 8:02:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:02:55 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 8:02:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:04 PM",
           "firstActor": "Kristie Ellis",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:03:04 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:15 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 8:03:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:20 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:03:20 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:22 PM",
           "firstActor": "Christopher Keates",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:03:22 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:29 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Angela Mueller",
-          "timestamp": "Nov 6, 2017 8:03:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:34 PM",
           "firstActor": "Angela Mueller",
-          "type": "PASS",
           "secondActor": "Kevin Hughes(S)",
-          "timestamp": "Nov 6, 2017 8:03:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:38 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:03:38 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:41 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:03:41 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:50 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:03:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:53 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 8:03:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:03:57 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:03:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:04:11 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 8:04:11 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:04:14 PM",
           "firstActor": "Martin Cloake",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:04:14 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2763,96 +2768,96 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Martin Cloake",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Kevin Barford",
-        "Brian Perry",
-        "Michael Wong",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:04:53 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Vanessa Mann",
-          "timestamp": "Nov 6, 2017 8:04:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:04:55 PM",
           "firstActor": "Vanessa Mann",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 8:04:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:04:58 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 8:04:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:00 PM",
           "firstActor": "Michael Wong",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 8:05:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:05 PM",
           "firstActor": "Brian Perry",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:05:05 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:07 PM",
           "firstActor": "Hannah Dawson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:05:07 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:33 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Nick Amlin",
-          "timestamp": "Nov 6, 2017 8:05:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:37 PM",
           "firstActor": "Nick Amlin",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 8:05:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:41 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:05:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:42 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 8:05:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:47 PM",
           "firstActor": "Tim Kealey",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:05:47 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:05:49 PM",
           "firstActor": "Christopher Keates",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:05:49 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:06:13 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 8:06:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:06:15 PM",
           "firstActor": "Kevin Barford",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:06:15 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2862,58 +2867,58 @@
         "Andrew Spearin",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Martin Cloake",
-        "Ben Curran",
-        "Tim Kealey",
-        "Jamie Wildgen",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:07:20 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 8:07:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:07:22 PM",
           "firstActor": "Ben Curran",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 8:07:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:07:24 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 8:07:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:07:30 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Marie-Ange Gravel",
-          "timestamp": "Nov 6, 2017 8:07:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:07:35 PM",
           "firstActor": "Marie-Ange Gravel",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 8:07:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:07:44 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Ben Curran",
-          "timestamp": "Nov 6, 2017 8:07:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:07:46 PM",
           "firstActor": "Ben Curran",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:07:46 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2923,34 +2928,34 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Kevin Barford",
-        "Patrick Kenzie",
-        "Brian Perry",
-        "Vanessa Mann",
-        "Andrea Proulx"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:08:34 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 8:08:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:08:58 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 8:08:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:08:59 PM",
           "firstActor": "Andrea Proulx",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:08:59 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2960,56 +2965,56 @@
         "Andrew Spearin",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Vanessa Mann",
+        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Nick Amlin",
-        "Martin Cloake",
-        "Ben Curran",
-        "Jamie Wildgen",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:09:43 PM",
           "firstActor": "Martin Cloake",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 8:09:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:09:46 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 8:09:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:09:55 PM",
           "firstActor": "Martin Cloake",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:09:55 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:09:57 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:09:57 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:10:04 PM",
           "firstActor": "Kevin Hughes(S)",
-          "type": "PASS",
           "secondActor": "Kevin Barford",
-          "timestamp": "Nov 6, 2017 8:10:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:10:12 PM",
           "firstActor": "Kevin Barford",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 8:10:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:10:14 PM",
           "firstActor": "Michael Wong",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:10:14 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3019,111 +3024,111 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Martin Cloake",
-        "Tim Kealey",
-        "Andrew Spearin",
-        "Hannah Dawson",
-        "Carrie-Anne Whyte"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:12:30 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 8:12:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:12:34 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:12:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:12:39 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 8:12:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:12:42 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
           "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:12:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:12:45 PM",
           "firstActor": "Andrew Spearin",
-          "type": "PASS",
           "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 8:12:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:12:48 PM",
           "firstActor": "Tim Kealey",
-          "type": "PASS",
           "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 8:12:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:12:51 PM",
           "firstActor": "Hannah Dawson",
-          "type": "PASS",
           "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 8:12:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:12:53 PM",
           "firstActor": "Carrie-Anne Whyte",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:12:53 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:00 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 8:13:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:02 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Vanessa Mann",
-          "timestamp": "Nov 6, 2017 8:13:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:05 PM",
           "firstActor": "Vanessa Mann",
-          "type": "PASS",
           "secondActor": "Patrick Kenzie",
-          "timestamp": "Nov 6, 2017 8:13:05 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:07 PM",
           "firstActor": "Patrick Kenzie",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 8:13:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:10 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Andrea Proulx",
-          "timestamp": "Nov 6, 2017 8:13:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:11 PM",
           "firstActor": "Andrea Proulx",
-          "type": "PASS",
           "secondActor": "Christopher Keates",
-          "timestamp": "Nov 6, 2017 8:13:11 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:19 PM",
           "firstActor": "Christopher Keates",
-          "type": "PASS",
           "secondActor": "Brian Perry",
-          "timestamp": "Nov 6, 2017 8:13:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:13:20 PM",
           "firstActor": "Brian Perry",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:13:20 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3133,56 +3138,56 @@
         "Brian Perry",
         "Vanessa Mann",
         "Andrea Proulx"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
       ]
     },
     {
-      "offensePlayers": [
-        "Brian Kells",
-        "Nick Amlin",
-        "Ben Curran",
-        "Jamie Wildgen",
-        "Marie-Ange Gravel",
-        "Katherine Matheson"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:14:16 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Katherine Matheson",
-          "timestamp": "Nov 6, 2017 8:14:16 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:14:20 PM",
           "firstActor": "Katherine Matheson",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 8:14:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:14:24 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 8:14:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:14:27 PM",
           "firstActor": "Jamie Wildgen",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:14:27 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:14:29 PM",
           "firstActor": "Michael Wong",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:14:29 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:14:34 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Michael Wong",
-          "timestamp": "Nov 6, 2017 8:14:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:14:35 PM",
           "firstActor": "Michael Wong",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:14:35 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3192,9 +3197,101 @@
         "Kevin Hughes(S)",
         "Kristie Ellis",
         "Angela Mueller"
+      ],
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Ben Curran",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:15:35 PM",
+          "firstActor": "Hannah Dawson",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:15:35 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:15:36 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Carrie-Anne Whyte",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:15:38 PM",
+          "firstActor": "Carrie-Anne Whyte",
+          "secondActor": "Tim Kealey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:15:44 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:05 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Martin Cloake",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:06 PM",
+          "firstActor": "Martin Cloake",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:19 PM",
+          "firstActor": "Patrick Kenzie",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:20 PM",
+          "firstActor": "Hannah Dawson",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:25 PM",
+          "firstActor": "Tim Kealey",
+          "secondActor": "Andrew Spearin",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:32 PM",
+          "firstActor": "Andrew Spearin",
+          "secondActor": "Hannah Dawson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:37 PM",
+          "firstActor": "Hannah Dawson",
+          "secondActor": "Jamie Wildgen",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:16:39 PM",
+          "firstActor": "Jamie Wildgen",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
       "offensePlayers": [
         "Martin Cloake",
         "Tim Kealey",
@@ -3202,140 +3299,48 @@
         "Jamie Wildgen",
         "Hannah Dawson",
         "Carrie-Anne Whyte"
-      ],
-      "events": [
-        {
-          "firstActor": "Hannah Dawson",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 8:15:35 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:15:35 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Carrie-Anne Whyte",
-          "timestamp": "Nov 6, 2017 8:15:36 PM"
-        },
-        {
-          "firstActor": "Carrie-Anne Whyte",
-          "type": "PASS",
-          "secondActor": "Tim Kealey",
-          "timestamp": "Nov 6, 2017 8:15:38 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:15:44 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 8:16:05 PM"
-        },
-        {
-          "firstActor": "Martin Cloake",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:16:06 PM"
-        },
-        {
-          "firstActor": "Patrick Kenzie",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:16:19 PM"
-        },
-        {
-          "firstActor": "Hannah Dawson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:16:20 PM"
-        },
-        {
-          "firstActor": "Tim Kealey",
-          "type": "PASS",
-          "secondActor": "Andrew Spearin",
-          "timestamp": "Nov 6, 2017 8:16:25 PM"
-        },
-        {
-          "firstActor": "Andrew Spearin",
-          "type": "PASS",
-          "secondActor": "Hannah Dawson",
-          "timestamp": "Nov 6, 2017 8:16:32 PM"
-        },
-        {
-          "firstActor": "Hannah Dawson",
-          "type": "PASS",
-          "secondActor": "Jamie Wildgen",
-          "timestamp": "Nov 6, 2017 8:16:37 PM"
-        },
-        {
-          "firstActor": "Jamie Wildgen",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:16:39 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Christopher Keates",
-        "Kevin Barford",
-        "Patrick Kenzie",
-        "Rob Tyson",
-        "Vanessa Mann",
-        "Andrea Proulx"
       ]
     },
     {
-      "offensePlayers": [
-        "Christopher Keates",
-        "Brian Perry",
-        "Michael Wong",
-        "Kevin Hughes(S)",
-        "Kristie Ellis",
-        "Angela Mueller"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:17:30 PM",
           "firstActor": "Brian Perry",
-          "type": "PASS",
           "secondActor": "Kristie Ellis",
-          "timestamp": "Nov 6, 2017 8:17:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:17:33 PM",
           "firstActor": "Kristie Ellis",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:17:33 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:17:35 PM",
           "firstActor": "Ben Curran",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:17:35 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:18:11 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Katherine Matheson",
-          "timestamp": "Nov 6, 2017 8:18:11 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:18:13 PM",
           "firstActor": "Katherine Matheson",
-          "type": "PASS",
           "secondActor": "Brian Kells",
-          "timestamp": "Nov 6, 2017 8:18:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:18:30 PM",
           "firstActor": "Brian Kells",
-          "type": "PASS",
           "secondActor": "Martin Cloake",
-          "timestamp": "Nov 6, 2017 8:18:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:18:31 PM",
           "firstActor": "Martin Cloake",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:18:31 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3345,36 +3350,29 @@
         "Ben Curran",
         "Marie-Ange Gravel",
         "Katherine Matheson"
+      ],
+      "offensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
       ]
     }
   ],
-  "league": "ocua_17-18",
-  "teams": {
-    "home_team": [
-      "Kristie Ellis",
-      "Vanessa Mann",
-      "Angela Mueller",
-      "Andrea Proulx",
-      "Christopher Keates",
-      "Kevin Barford",
-      "Patrick Kenzie",
-      "Brian Perry",
-      "Rob Tyson",
-      "Michael Wong",
-      "Kevin Hughes(S)"
-    ],
-    "away_team": [
-      "Hannah Dawson",
-      "Marie-Ange Gravel",
-      "Katherine Matheson",
-      "Carrie-Anne Whyte",
-      "Brian Kells",
-      "Nick Amlin",
-      "Martin Cloake",
-      "Ben Curran",
-      "Tim Kealey",
-      "Andrew Spearin",
-      "Jamie Wildgen"
-    ]
-  }
+  "week": 1,
+  "homeRoster": [
+    "Kristie Ellis",
+    "Vanessa Mann",
+    "Angela Mueller",
+    "Andrea Proulx",
+    "Christopher Keates",
+    "Kevin Barford",
+    "Patrick Kenzie",
+    "Brian Perry",
+    "Rob Tyson",
+    "Michael Wong",
+    "Kevin Hughes(S)"
+  ]
 }

--- a/data/ocua_17-18/week1_game1.json
+++ b/data/ocua_17-18/week1_game1.json
@@ -1,0 +1,3380 @@
+{
+  "score": {
+    "home_team": 17,
+    "away_team": 19
+  },
+  "week": 1,
+  "points": [
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PULL",
+          "timestamp": "Nov 6, 2017 7:07:09 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 7:07:59 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:08:01 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:08:07 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:08:24 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:08:26 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:08:31 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:08:34 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:08:39 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:08:40 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Ben Curran",
+        "Tim Kealey",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:09:34 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:09:37 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 7:09:40 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:09:43 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:09:44 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:09:48 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:09:50 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Vanessa Mann"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kevin Barford",
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:10:53 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:11:05 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:11:08 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:11:08 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:11:12 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:11:13 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Ben Curran",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Patrick Kenzie",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Vanessa Mann",
+          "timestamp": "Nov 6, 2017 7:12:14 PM"
+        },
+        {
+          "firstActor": "Vanessa Mann",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:12:15 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 7:12:22 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:12:23 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kevin Barford",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:13:12 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Rob Tyson",
+          "timestamp": "Nov 6, 2017 7:13:17 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:13:24 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:13:27 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:13:31 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:13:50 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:13:51 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Nick Amlin",
+          "timestamp": "Nov 6, 2017 7:13:56 PM"
+        },
+        {
+          "firstActor": "Nick Amlin",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:13:58 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:14:01 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:14:07 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:14:12 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:14:13 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:14:58 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:15:02 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:15:05 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 7:15:09 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:15:13 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:15:13 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:15:19 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:15:42 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:15:47 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:15:49 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:15:54 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:16:04 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:16:08 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Martin Cloake",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
+      "events": [
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:16:42 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:16:45 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:16:49 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:16:53 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:16:55 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:16:57 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:17:00 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:17:07 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:17:11 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:17:17 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 7:17:18 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:17:19 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:17:21 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:17:26 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:17:28 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:17:32 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:17:35 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:17:38 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:17:43 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:17:46 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:17:48 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:17:50 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:17:53 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:18:16 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:18:19 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:18:23 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:18:25 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:18:27 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 7:18:30 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:18:31 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Nick Amlin",
+          "timestamp": "Nov 6, 2017 7:19:20 PM"
+        },
+        {
+          "firstActor": "Nick Amlin",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:19:24 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 7:19:28 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:19:31 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Katherine Matheson",
+          "timestamp": "Nov 6, 2017 7:19:38 PM"
+        },
+        {
+          "firstActor": "Katherine Matheson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:19:39 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:20:19 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:20:22 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 7:20:24 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:20:28 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:20:41 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:20:45 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:20:49 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:20:52 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:20:54 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:21:04 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:21:32 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:21:34 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:21:39 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:21:40 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:22:17 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:22:21 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:22:27 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:22:29 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:22:43 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:22:49 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:22:53 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:22:55 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:22:57 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:23:00 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Nick Amlin",
+          "timestamp": "Nov 6, 2017 7:23:04 PM"
+        },
+        {
+          "firstActor": "Nick Amlin",
+          "type": "PASS",
+          "secondActor": "Katherine Matheson",
+          "timestamp": "Nov 6, 2017 7:23:10 PM"
+        },
+        {
+          "firstActor": "Katherine Matheson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:23:12 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 7:23:56 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:24:02 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:24:02 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:24:10 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:24:15 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:24:20 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:24:28 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:24:29 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:24:32 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:24:33 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Tim Kealey",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:25:17 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:25:21 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:25:25 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:25:27 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:25:32 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:25:37 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:25:38 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:25:44 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:25:45 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Ben Curran",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
+      "events": [
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:26:25 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:26:29 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:26:30 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:26:35 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:26:39 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:26:42 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:26:46 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:26:50 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:26:53 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:26:57 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:27:00 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:27:04 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:27:10 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:27:16 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:27:17 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:27:18 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:27:22 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:27:25 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:27:29 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:27:31 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:27:36 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:27:38 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:27:40 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:27:42 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:28:39 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:28:40 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:28:41 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:28:42 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:28:43 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:28:44 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:28:46 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:28:53 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:28:54 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Ben Curran",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
+      "events": [
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:29:42 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:29:46 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:29:48 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:29:51 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:30:10 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:30:14 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:30:17 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:30:19 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Rob Tyson",
+          "timestamp": "Nov 6, 2017 7:30:22 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:30:24 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:30:26 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:30:37 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:30:39 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:30:48 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:30:53 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:30:59 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:31:02 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:31:04 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:31:18 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:31:29 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:31:30 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kevin Barford",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:32:14 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:32:23 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:32:34 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:32:41 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:33:26 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:33:28 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Rob Tyson",
+          "timestamp": "Nov 6, 2017 7:33:31 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:33:36 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:33:41 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:33:46 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:33:51 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:33:56 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:33:58 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:34:01 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:34:10 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:34:11 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:35:01 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:35:05 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:35:06 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:36:44 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:36:46 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:35:01 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:35:05 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:35:06 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:36:44 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:36:46 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:37:24 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:37:31 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:37:33 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:37:42 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:37:43 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:37:43 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:37:48 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:37:50 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Rob Tyson",
+          "timestamp": "Nov 6, 2017 7:38:24 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:38:25 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:38:30 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:38:48 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:38:49 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:38:50 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:38:51 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:38:53 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:39:21 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:39:25 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 7:39:30 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:39:33 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:39:35 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 7:39:40 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:39:44 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 7:39:46 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:39:52 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:39:53 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Martin Cloake",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:40:33 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:40:40 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:40:44 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:40:47 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Rob Tyson",
+          "timestamp": "Nov 6, 2017 7:40:49 PM"
+        },
+        {
+          "firstActor": "Rob Tyson",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:40:53 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Vanessa Mann",
+          "timestamp": "Nov 6, 2017 7:40:58 PM"
+        },
+        {
+          "firstActor": "Vanessa Mann",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:41:03 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:41:04 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Ben Curran",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
+      "events": [
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:41:54 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:41:57 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:42:01 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:42:07 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:42:10 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:42:11 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:42:58 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:43:02 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:43:05 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:43:10 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:43:26 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 7:43:29 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:43:30 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:43:40 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:43:45 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:43:46 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:44:02 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:44:06 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:44:11 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Martin Cloake",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nick Amlin",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
+      "events": [
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PULL",
+          "timestamp": "Nov 6, 2017 7:49:22 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:50:23 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:50:26 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:50:29 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:50:32 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:50:35 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:50:37 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:50:39 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:50:42 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:50:45 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:50:47 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:50:48 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:50:57 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:51:12 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:51:17 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:51:23 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:51:27 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:51:29 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:51:33 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:51:38 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:51:44 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:51:50 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Nick Amlin",
+          "timestamp": "Nov 6, 2017 7:51:53 PM"
+        },
+        {
+          "firstActor": "Nick Amlin",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:51:56 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:52:00 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:52:01 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 7:52:49 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 7:52:52 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:52:56 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:53:24 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 7:53:31 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:53:41 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:53:48 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:53:49 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:54:26 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:54:31 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 7:54:39 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 7:54:47 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:54:49 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Vanessa Mann",
+          "timestamp": "Nov 6, 2017 7:54:57 PM"
+        },
+        {
+          "firstActor": "Vanessa Mann",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:54:59 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:55:00 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:55:18 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 7:55:20 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:55:23 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Nick Amlin",
+          "timestamp": "Nov 6, 2017 7:55:30 PM"
+        },
+        {
+          "firstActor": "Nick Amlin",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:55:34 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:55:38 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:55:41 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:55:44 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:55:48 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:55:50 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:55:53 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:55:55 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:56:00 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:56:01 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:56:04 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:56:07 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:56:28 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:56:34 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:56:37 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:56:39 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 7:56:44 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:56:48 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 7:57:21 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 7:57:23 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:57:34 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 7:57:37 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 7:57:40 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 7:57:45 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 7:57:51 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 7:57:53 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 7:57:59 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:58:00 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 7:58:53 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 7:59:00 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 7:59:51 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 7:59:52 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Vanessa Mann",
+          "timestamp": "Nov 6, 2017 8:00:32 PM"
+        },
+        {
+          "firstActor": "Vanessa Mann",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 8:00:34 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 8:00:40 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 8:00:46 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 8:00:49 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 8:00:51 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 8:00:56 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 8:01:00 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:01:01 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Tim Kealey",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Martin Cloake",
+        "Ben Curran",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 8:02:04 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:02:09 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Katherine Matheson",
+          "timestamp": "Nov 6, 2017 8:02:15 PM"
+        },
+        {
+          "firstActor": "Katherine Matheson",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 8:02:16 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 8:02:18 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 8:02:21 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:02:26 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:02:34 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:02:36 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 8:02:50 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 8:02:55 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:03:04 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 8:03:15 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:03:20 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:03:22 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Angela Mueller",
+          "timestamp": "Nov 6, 2017 8:03:29 PM"
+        },
+        {
+          "firstActor": "Angela Mueller",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes(S)",
+          "timestamp": "Nov 6, 2017 8:03:34 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:03:38 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:03:41 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:03:50 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 8:03:53 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:03:57 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 8:04:11 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:04:14 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Brian Perry",
+        "Michael Wong",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Vanessa Mann",
+          "timestamp": "Nov 6, 2017 8:04:53 PM"
+        },
+        {
+          "firstActor": "Vanessa Mann",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 8:04:55 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 8:04:58 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 8:05:00 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:05:05 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:05:07 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Nick Amlin",
+          "timestamp": "Nov 6, 2017 8:05:33 PM"
+        },
+        {
+          "firstActor": "Nick Amlin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 8:05:37 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:05:41 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 8:05:42 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:05:47 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:05:49 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 8:06:13 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:06:15 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Martin Cloake",
+        "Ben Curran",
+        "Tim Kealey",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 8:07:20 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 8:07:22 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 8:07:24 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Marie-Ange Gravel",
+          "timestamp": "Nov 6, 2017 8:07:30 PM"
+        },
+        {
+          "firstActor": "Marie-Ange Gravel",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 8:07:35 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Ben Curran",
+          "timestamp": "Nov 6, 2017 8:07:44 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:07:46 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 8:08:34 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 8:08:58 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:08:59 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Martin Cloake",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 8:09:43 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 8:09:46 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:09:55 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:09:57 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Barford",
+          "timestamp": "Nov 6, 2017 8:10:04 PM"
+        },
+        {
+          "firstActor": "Kevin Barford",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 8:10:12 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:10:14 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kevin Barford",
+        "Rob Tyson",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 8:12:30 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:12:34 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 8:12:39 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:12:42 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 8:12:45 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 8:12:48 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 8:12:51 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:12:53 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 8:13:00 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Vanessa Mann",
+          "timestamp": "Nov 6, 2017 8:13:02 PM"
+        },
+        {
+          "firstActor": "Vanessa Mann",
+          "type": "PASS",
+          "secondActor": "Patrick Kenzie",
+          "timestamp": "Nov 6, 2017 8:13:05 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 8:13:07 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx",
+          "timestamp": "Nov 6, 2017 8:13:10 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx",
+          "type": "PASS",
+          "secondActor": "Christopher Keates",
+          "timestamp": "Nov 6, 2017 8:13:11 PM"
+        },
+        {
+          "firstActor": "Christopher Keates",
+          "type": "PASS",
+          "secondActor": "Brian Perry",
+          "timestamp": "Nov 6, 2017 8:13:19 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:13:20 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Brian Perry",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Ben Curran",
+        "Jamie Wildgen",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Katherine Matheson",
+          "timestamp": "Nov 6, 2017 8:14:16 PM"
+        },
+        {
+          "firstActor": "Katherine Matheson",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 8:14:20 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 8:14:24 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:14:27 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:14:29 PM"
+        },
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Michael Wong",
+          "timestamp": "Nov 6, 2017 8:14:34 PM"
+        },
+        {
+          "firstActor": "Michael Wong",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:14:35 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Perry",
+        "Rob Tyson",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Martin Cloake",
+        "Tim Kealey",
+        "Andrew Spearin",
+        "Jamie Wildgen",
+        "Hannah Dawson",
+        "Carrie-Anne Whyte"
+      ],
+      "events": [
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 8:15:35 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:15:35 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Carrie-Anne Whyte",
+          "timestamp": "Nov 6, 2017 8:15:36 PM"
+        },
+        {
+          "firstActor": "Carrie-Anne Whyte",
+          "type": "PASS",
+          "secondActor": "Tim Kealey",
+          "timestamp": "Nov 6, 2017 8:15:38 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:15:44 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 8:16:05 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:16:06 PM"
+        },
+        {
+          "firstActor": "Patrick Kenzie",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:16:19 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:16:20 PM"
+        },
+        {
+          "firstActor": "Tim Kealey",
+          "type": "PASS",
+          "secondActor": "Andrew Spearin",
+          "timestamp": "Nov 6, 2017 8:16:25 PM"
+        },
+        {
+          "firstActor": "Andrew Spearin",
+          "type": "PASS",
+          "secondActor": "Hannah Dawson",
+          "timestamp": "Nov 6, 2017 8:16:32 PM"
+        },
+        {
+          "firstActor": "Hannah Dawson",
+          "type": "PASS",
+          "secondActor": "Jamie Wildgen",
+          "timestamp": "Nov 6, 2017 8:16:37 PM"
+        },
+        {
+          "firstActor": "Jamie Wildgen",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:16:39 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Christopher Keates",
+        "Kevin Barford",
+        "Patrick Kenzie",
+        "Rob Tyson",
+        "Vanessa Mann",
+        "Andrea Proulx"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Christopher Keates",
+        "Brian Perry",
+        "Michael Wong",
+        "Kevin Hughes(S)",
+        "Kristie Ellis",
+        "Angela Mueller"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry",
+          "type": "PASS",
+          "secondActor": "Kristie Ellis",
+          "timestamp": "Nov 6, 2017 8:17:30 PM"
+        },
+        {
+          "firstActor": "Kristie Ellis",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:17:33 PM"
+        },
+        {
+          "firstActor": "Ben Curran",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:17:35 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Katherine Matheson",
+          "timestamp": "Nov 6, 2017 8:18:11 PM"
+        },
+        {
+          "firstActor": "Katherine Matheson",
+          "type": "PASS",
+          "secondActor": "Brian Kells",
+          "timestamp": "Nov 6, 2017 8:18:13 PM"
+        },
+        {
+          "firstActor": "Brian Kells",
+          "type": "PASS",
+          "secondActor": "Martin Cloake",
+          "timestamp": "Nov 6, 2017 8:18:30 PM"
+        },
+        {
+          "firstActor": "Martin Cloake",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:18:31 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Brian Kells",
+        "Nick Amlin",
+        "Martin Cloake",
+        "Ben Curran",
+        "Marie-Ange Gravel",
+        "Katherine Matheson"
+      ]
+    }
+  ],
+  "league": "ocua_17-18",
+  "teams": {
+    "home_team": [
+      "Kristie Ellis",
+      "Vanessa Mann",
+      "Angela Mueller",
+      "Andrea Proulx",
+      "Christopher Keates",
+      "Kevin Barford",
+      "Patrick Kenzie",
+      "Brian Perry",
+      "Rob Tyson",
+      "Michael Wong",
+      "Kevin Hughes(S)"
+    ],
+    "away_team": [
+      "Hannah Dawson",
+      "Marie-Ange Gravel",
+      "Katherine Matheson",
+      "Carrie-Anne Whyte",
+      "Brian Kells",
+      "Nick Amlin",
+      "Martin Cloake",
+      "Ben Curran",
+      "Tim Kealey",
+      "Andrew Spearin",
+      "Jamie Wildgen"
+    ]
+  }
+}

--- a/data/ocua_17-18/week1_game2.json
+++ b/data/ocua_17-18/week1_game2.json
@@ -1,127 +1,133 @@
 {
-  "score": {
-    "home_team": 23,
-    "away_team": 11
-  },
-  "week": 1,
+  "awayRoster": [
+    "Kate Achtell",
+    "Celine Dumais",
+    "Josee Guibord",
+    "Alix Ranger",
+    "Logan Ashall",
+    "Marcus Bordage",
+    "Kelsey Charie",
+    "Kevin Hughes",
+    "Thomas Sattolo",
+    "Dan Thomson",
+    "Edwin Wong",
+    "Brian Perry(S)"
+  ],
+  "awayTeam": "Last Jedi",
+  "homeTeam": "Sultimate Fight Club",
+  "awayScore": 11,
+  "league": "ocua_17-18",
+  "homeScore": 23,
   "points": [
     {
-      "offensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:25:44 PM",
           "firstActor": "Marcus Bordage",
-          "type": "PULL",
-          "timestamp": "Nov 6, 2017 8:25:44 PM"
+          "type": "PULL"
         },
         {
+          "timestamp": "Nov 6, 2017 8:25:56 PM",
           "firstActor": "Chris Sullivan",
-          "type": "PASS",
           "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 8:25:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:00 PM",
           "firstActor": "Nicole MacDonald",
-          "type": "PASS",
           "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:26:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:04 PM",
           "firstActor": "Dominique Rioux",
-          "type": "PASS",
           "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:26:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:08 PM",
           "firstActor": "Stephen Close",
-          "type": "PASS",
           "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:26:08 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:10 PM",
           "firstActor": "Jon Rowe",
-          "type": "PASS",
           "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 8:26:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:15 PM",
           "firstActor": "Nicole MacDonald",
-          "type": "PASS",
           "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:26:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:21 PM",
           "firstActor": "Jon Rowe",
-          "type": "PASS",
           "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:26:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:23 PM",
           "firstActor": "Chris Sullivan",
-          "type": "PASS",
           "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 8:26:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:38 PM",
           "firstActor": "Nicole MacDonald",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:26:38 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:43 PM",
           "firstActor": "Logan Ashall",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:26:43 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:45 PM",
           "firstActor": "Logan Ashall",
-          "type": "PASS",
           "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:26:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:46 PM",
           "firstActor": "Josee Guibord",
-          "type": "PASS",
           "secondActor": "Edwin Wong",
-          "timestamp": "Nov 6, 2017 8:26:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:50 PM",
           "firstActor": "Edwin Wong",
-          "type": "PASS",
           "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:26:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:54 PM",
           "firstActor": "Josee Guibord",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:26:54 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:26:58 PM",
           "firstActor": "Jon Rowe",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:26:58 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:27:01 PM",
           "firstActor": "Chris Sullivan",
-          "type": "PASS",
           "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:27:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:27:05 PM",
           "firstActor": "Stephen Close",
-          "type": "PASS",
           "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:27:05 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:27:30 PM",
           "firstActor": "Derek Tokarski",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:27:30 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -131,2641 +137,298 @@
         "Edwin Wong",
         "Celine Dumais",
         "Josee Guibord"
+      ],
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
       ]
     },
     {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:28:26 PM",
           "firstActor": "Brian Perry(S)",
-          "type": "PASS",
           "secondActor": "Alix Ranger",
-          "timestamp": "Nov 6, 2017 8:28:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:28:27 PM",
           "firstActor": "Alix Ranger",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:28:27 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 8:28:38 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 8:28:39 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:28:48 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:28:55 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:29:01 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:29:09 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:29:35 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:29:40 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:29:42 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:29:46 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:29:48 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:29:51 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:29:56 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:30:03 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Liam Parker",
-          "timestamp": "Nov 6, 2017 8:30:21 PM"
-        },
-        {
-          "firstActor": "Liam Parker",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 8:30:24 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 8:30:28 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:30:29 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:31:12 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:31:18 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:31:24 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 8:31:28 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:31:33 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:31:54 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:31:57 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:32:02 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:32:04 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Celine Dumais",
-          "timestamp": "Nov 6, 2017 8:32:08 PM"
-        },
-        {
-          "firstActor": "Celine Dumais",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:32:12 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:32:17 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:32:32 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:32:36 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:32:37 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 8:33:22 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 8:33:27 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:33:27 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 8:33:32 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 8:33:35 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Liam Parker",
-          "timestamp": "Nov 6, 2017 8:33:40 PM"
-        },
-        {
-          "firstActor": "Liam Parker",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:33:41 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:34:23 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 8:34:28 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 8:34:30 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 8:34:32 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:34:36 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:34:44 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:34:48 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:34:56 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:35:00 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:35:04 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:35:08 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:35:11 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:35:17 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:35:21 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:35:27 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:35:45 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:35:49 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:35:53 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:35:55 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:36:15 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:36:18 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Edwin Wong",
-          "timestamp": "Nov 6, 2017 8:36:22 PM"
-        },
-        {
-          "firstActor": "Edwin Wong",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:36:23 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Celine Dumais",
-          "timestamp": "Nov 6, 2017 8:36:28 PM"
-        },
-        {
-          "firstActor": "Celine Dumais",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 8:36:30 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 8:36:34 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:36:38 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Celine Dumais",
-          "timestamp": "Nov 6, 2017 8:36:42 PM"
-        },
-        {
-          "firstActor": "Celine Dumais",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:36:46 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:36:48 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:36:51 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:36:56 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:36:58 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Edwin Wong",
-          "timestamp": "Nov 6, 2017 8:37:13 PM"
-        },
-        {
-          "firstActor": "Edwin Wong",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:37:16 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:37:23 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 8:37:27 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:37:27 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ],
-      "events": [
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 8:38:21 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:38:25 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:38:36 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:38:39 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Alix Ranger",
-          "timestamp": "Nov 6, 2017 8:38:46 PM"
-        },
-        {
-          "firstActor": "Alix Ranger",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:38:50 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:38:56 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:38:57 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 8:39:10 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 8:39:11 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 8:39:22 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:39:23 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:39:30 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:39:34 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 8:39:52 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:39:53 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:40:04 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:40:05 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ],
-      "events": [
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:41:00 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 8:41:03 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:41:08 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:41:14 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:41:16 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:41:17 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:41:20 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:41:21 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 8:42:05 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:42:09 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:42:13 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:42:21 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:42:22 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:42:29 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:42:31 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 8:42:36 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 8:42:40 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 8:42:41 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:42:46 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:42:47 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:43:07 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:43:11 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Liam Parker",
-          "timestamp": "Nov 6, 2017 8:43:27 PM"
-        },
-        {
-          "firstActor": "Liam Parker",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 8:43:30 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 8:43:32 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 8:43:38 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:43:39 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:44:33 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:44:44 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:44:47 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:44:54 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:44:56 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:45:03 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:45:06 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:45:09 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:45:12 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 8:45:14 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:45:19 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:45:19 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:48:34 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:48:38 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:48:45 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:48:47 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:48:49 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:48:55 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 8:49:02 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:49:07 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Alix Ranger",
-          "timestamp": "Nov 6, 2017 8:49:10 PM"
-        },
-        {
-          "firstActor": "Alix Ranger",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:49:11 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ],
-      "events": [
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:49:56 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:50:03 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:50:14 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:50:15 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:50:55 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:50:56 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Alix Ranger",
-          "timestamp": "Nov 6, 2017 8:50:59 PM"
-        },
-        {
-          "firstActor": "Alix Ranger",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 8:51:04 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:51:06 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 8:51:15 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:51:16 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:51:59 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 8:52:01 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:52:03 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:52:08 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:52:11 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:52:14 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:52:17 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:52:19 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:52:23 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 8:52:31 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:52:36 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:52:39 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 8:52:44 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:52:48 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:52:53 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:52:59 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 8:53:11 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:53:13 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:53:18 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 8:53:20 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 8:53:22 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:53:23 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:53:26 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:53:31 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:53:37 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:53:37 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:54:12 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 8:54:17 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:55:09 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:55:14 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 8:55:18 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:55:23 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:55:27 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 8:55:30 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:55:37 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 8:55:41 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:55:46 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:55:55 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 8:56:03 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:56:05 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 8:56:25 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:56:26 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ],
-      "events": [
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 8:57:07 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 8:57:08 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 8:57:12 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 8:57:15 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 8:57:21 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 8:57:31 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 8:57:31 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:57:33 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 8:58:31 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 8:58:36 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 8:58:43 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:58:46 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:58:52 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:58:55 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 8:59:00 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 8:59:04 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 8:59:10 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 8:59:11 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ],
-      "events": [
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 8:59:56 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:00:00 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:00:27 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:00:33 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:00:38 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:00:53 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:00:56 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 9:01:14 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 9:01:17 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Nicole MacDonald",
-          "timestamp": "Nov 6, 2017 9:01:19 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 9:01:24 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 9:01:29 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 9:01:36 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:01:36 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Kevin Hughes",
-        "Thomas Sattolo",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:02:23 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 9:02:28 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 9:02:31 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 9:02:34 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 9:02:40 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:02:46 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Alix Ranger",
-          "timestamp": "Nov 6, 2017 9:02:52 PM"
-        },
-        {
-          "firstActor": "Alix Ranger",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 9:02:58 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:03:00 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 9:03:02 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:03:10 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:03:12 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:03:15 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:03:15 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:03:17 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 9:03:18 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:03:22 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 9:03:31 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 9:03:33 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:03:34 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Dan Thomson",
-        "Edwin Wong",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:04:15 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:04:17 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:04:31 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:04:35 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:04:45 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:04:48 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:04:51 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:04:53 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:04:55 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:04:58 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:04:59 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Thomas Sattolo",
-        "Edwin Wong",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:10:08 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:10:28 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Liam Parker",
-          "timestamp": "Nov 6, 2017 9:10:30 PM"
-        },
-        {
-          "firstActor": "Liam Parker",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:10:35 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:10:40 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:10:46 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 9:10:48 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 9:10:53 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:10:54 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Kevin Hughes",
-        "Dan Thomson",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Celine Dumais",
-          "timestamp": "Nov 6, 2017 9:11:50 PM"
-        },
-        {
-          "firstActor": "Celine Dumais",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:11:52 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:11:57 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:12:07 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:12:09 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "PASS",
-          "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 9:12:20 PM"
-        },
-        {
-          "firstActor": "Chris Sullivan",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 9:12:27 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "PASS",
-          "secondActor": "Derek Tokarski",
-          "timestamp": "Nov 6, 2017 9:12:30 PM"
-        },
-        {
-          "firstActor": "Derek Tokarski",
-          "type": "PASS",
-          "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 9:12:33 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:12:34 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Thomas Sattolo",
-        "Edwin Wong",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Kate Achtell",
-          "timestamp": "Nov 6, 2017 9:13:19 PM"
-        },
-        {
-          "firstActor": "Kate Achtell",
-          "type": "PASS",
-          "secondActor": "Kelsey Charie",
-          "timestamp": "Nov 6, 2017 9:13:24 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Edwin Wong",
-          "timestamp": "Nov 6, 2017 9:13:31 PM"
-        },
-        {
-          "firstActor": "Edwin Wong",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:13:34 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 9:14:04 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 9:14:05 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:14:07 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:14:14 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:14:17 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 9:14:19 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:14:36 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:15:02 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 9:15:08 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:15:17 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:15:17 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Kevin Hughes",
-        "Dan Thomson",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:16:04 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:16:10 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:16:14 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:16:16 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:16:20 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:16:22 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:16:24 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:16:27 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Celine Dumais",
-          "timestamp": "Nov 6, 2017 9:16:38 PM"
-        },
-        {
-          "firstActor": "Celine Dumais",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:16:39 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ],
-      "events": [
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:17:37 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 9:17:41 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:17:41 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Kelsey Charie",
-        "Thomas Sattolo",
-        "Edwin Wong",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Kevin Hughes",
-        "Dan Thomson",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:18:28 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:18:30 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:18:34 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Celine Dumais",
-          "timestamp": "Nov 6, 2017 9:18:37 PM"
-        },
-        {
-          "firstActor": "Celine Dumais",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:18:43 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:18:49 PM"
-        },
-        {
-          "firstActor": "Nicole MacDonald",
-          "type": "PASS",
-          "secondActor": "Stephen Close",
-          "timestamp": "Nov 6, 2017 9:18:56 PM"
-        },
-        {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
-          "secondActor": "Dominique Rioux",
-          "timestamp": "Nov 6, 2017 9:19:01 PM"
-        },
-        {
-          "firstActor": "Dominique Rioux",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:19:02 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Kelsey Charie",
-        "Thomas Sattolo",
-        "Edwin Wong",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ],
-      "events": [
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 9:19:42 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:19:45 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:19:52 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:19:54 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:20:00 PM"
-        },
-        {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:20:05 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Liam Parker",
-          "timestamp": "Nov 6, 2017 9:20:07 PM"
-        },
-        {
-          "firstActor": "Liam Parker",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:20:08 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Kevin Hughes",
-        "Dan Thomson",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:20:53 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:21:01 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:21:06 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:21:10 PM"
-        },
-        {
-          "timestamp": "Nov 6, 2017 9:21:20 PM",
           "type": "DROP"
         },
         {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:21:23 PM"
+          "timestamp": "Nov 6, 2017 8:28:38 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
         },
         {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 8:28:39 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:28:48 PM",
+          "firstActor": "Sebastien Belanger",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:28:55 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:01 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:09 PM",
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:35 PM",
+          "firstActor": "Micheal Davidson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:40 PM",
+          "firstActor": "Thomas Sattolo",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:42 PM",
+          "firstActor": "Thomas Sattolo",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:46 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:48 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:51 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:29:56 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:30:03 PM",
+          "firstActor": "Kelsey Charie",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:30:21 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Liam Parker",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:30:24 PM",
+          "firstActor": "Liam Parker",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:30:28 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:30:29 PM",
+          "firstActor": "Micheal Davidson",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:31:12 PM",
+          "firstActor": "Marcus Bordage",
           "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:21:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:31:18 PM",
           "firstActor": "Dan Thomson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:21:40 PM"
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
         },
         {
-          "firstActor": "Stephen Close",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 8:31:24 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:31:28 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:31:33 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:31:54 PM",
+          "firstActor": "Chris Sullivan",
           "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 9:21:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:31:57 PM",
           "firstActor": "Jon Rowe",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:21:49 PM"
+          "secondActor": "Stephen Close",
+          "type": "PASS"
         },
         {
-          "timestamp": "Nov 6, 2017 9:21:50 PM",
+          "timestamp": "Nov 6, 2017 8:32:02 PM",
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:32:04 PM",
+          "firstActor": "Logan Ashall",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:32:08 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Celine Dumais",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:32:12 PM",
+          "firstActor": "Celine Dumais",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:32:17 PM",
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:32:32 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:32:36 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:32:37 PM",
+          "firstActor": "Dominique Rioux",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:33:22 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:33:27 PM",
+          "firstActor": "Thomas Sattolo",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:33:27 PM",
+          "firstActor": "Kate Achtell",
           "type": "DROP"
         },
         {
-          "firstActor": "Derek Tokarski",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:21:55 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:22:01 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:22:03 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:22:05 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:22:13 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:22:13 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:22:15 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ],
-      "events": [
-        {
+          "timestamp": "Nov 6, 2017 8:33:32 PM",
           "firstActor": "Sebastien Belanger",
-          "type": "PASS",
           "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:23:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:33:35 PM",
           "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
           "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:23:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:33:40 PM",
           "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:23:09 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 9:23:12 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:23:16 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:23:17 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Edwin Wong",
-          "timestamp": "Nov 6, 2017 9:23:23 PM"
-        },
-        {
-          "firstActor": "Edwin Wong",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:23:28 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:23:30 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
           "secondActor": "Liam Parker",
-          "timestamp": "Nov 6, 2017 9:23:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:33:41 PM",
           "firstActor": "Liam Parker",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:23:33 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
-        "Kelsey Charie",
-        "Thomas Sattolo",
-        "Edwin Wong",
-        "Brian Perry(S)",
-        "Kate Achtell",
-        "Alix Ranger"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Kevin Hughes",
-        "Dan Thomson",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
-      "events": [
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:24:21 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:24:23 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:24:25 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:24:28 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:24:33 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:24:34 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Chris Sullivan",
-        "Stephen Close",
-        "Jon Rowe",
-        "Derek Tokarski",
-        "Nicole MacDonald",
-        "Dominique Rioux"
-      ]
-    },
-    {
-      "offensePlayers": [
         "Sebastien Belanger",
         "Micheal Davidson",
         "Liam Parker",
@@ -2773,199 +436,232 @@
         "Laura Chambers Storey",
         "An Tran"
       ],
-      "events": [
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:25:24 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "Liam Parker",
-          "timestamp": "Nov 6, 2017 9:25:28 PM"
-        },
-        {
-          "firstActor": "Liam Parker",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:25:31 PM"
-        },
-        {
-          "firstActor": "David Townsend",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:25:33 PM"
-        }
-      ],
-      "defensePlayers": [
+      "offensePlayers": [
         "Kelsey Charie",
+        "Kevin Hughes",
         "Thomas Sattolo",
-        "Edwin Wong",
         "Brian Perry(S)",
         "Kate Achtell",
         "Alix Ranger"
       ]
     },
     {
-      "offensePlayers": [
-        "Logan Ashall",
-        "Marcus Bordage",
-        "Kevin Hughes",
-        "Dan Thomson",
-        "Celine Dumais",
-        "Josee Guibord"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 8:34:23 PM",
           "firstActor": "Marcus Bordage",
-          "type": "PASS",
           "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:26:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:34:28 PM",
           "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:26:27 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
           "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:26:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:34:30 PM",
           "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:26:41 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:26:45 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:26:48 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
           "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:26:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:34:32 PM",
           "firstActor": "Marcus Bordage",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:26:57 PM"
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:34:36 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:34:44 PM",
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:34:48 PM",
           "firstActor": "Derek Tokarski",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:27:00 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 8:34:56 PM",
           "firstActor": "Nicole MacDonald",
-          "type": "PASS",
           "secondActor": "Jon Rowe",
-          "timestamp": "Nov 6, 2017 9:27:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:35:00 PM",
           "firstActor": "Jon Rowe",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:27:24 PM"
+          "secondActor": "Stephen Close",
+          "type": "PASS"
         },
         {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:27:39 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:27:46 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:27:53 PM"
-        },
-        {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Celine Dumais",
-          "timestamp": "Nov 6, 2017 9:27:56 PM"
-        },
-        {
-          "firstActor": "Celine Dumais",
-          "type": "PASS",
-          "secondActor": "Kevin Hughes",
-          "timestamp": "Nov 6, 2017 9:28:00 PM"
-        },
-        {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:28:02 PM"
-        },
-        {
-          "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:28:06 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:28:08 PM"
-        },
-        {
+          "timestamp": "Nov 6, 2017 8:35:04 PM",
           "firstActor": "Stephen Close",
-          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:35:08 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:35:11 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:35:17 PM",
+          "firstActor": "Dominique Rioux",
           "secondActor": "Chris Sullivan",
-          "timestamp": "Nov 6, 2017 9:28:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 8:35:21 PM",
           "firstActor": "Chris Sullivan",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:28:32 PM"
+          "secondActor": "Stephen Close",
+          "type": "PASS"
         },
         {
-          "firstActor": "Kevin Hughes",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:28:50 PM"
+          "timestamp": "Nov 6, 2017 8:35:27 PM",
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY"
         },
         {
-          "firstActor": "Josee Guibord",
-          "type": "PASS",
-          "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:28:54 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Logan Ashall",
-          "timestamp": "Nov 6, 2017 9:28:57 PM"
-        },
-        {
+          "timestamp": "Nov 6, 2017 8:35:45 PM",
           "firstActor": "Logan Ashall",
-          "type": "PASS",
-          "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:29:01 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 8:35:49 PM",
+          "firstActor": "Dominique Rioux",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:35:53 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:35:55 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:15 PM",
+          "firstActor": "Chris Sullivan",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:18 PM",
+          "firstActor": "Dan Thomson",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:22 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Edwin Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:23 PM",
+          "firstActor": "Edwin Wong",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:28 PM",
           "firstActor": "Josee Guibord",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:29:02 PM"
+          "secondActor": "Celine Dumais",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:30 PM",
+          "firstActor": "Celine Dumais",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:34 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:38 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:42 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Celine Dumais",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:46 PM",
+          "firstActor": "Celine Dumais",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:48 PM",
+          "firstActor": "Chris Sullivan",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:51 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:56 PM",
+          "firstActor": "Jon Rowe",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:36:58 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:37:13 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Edwin Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:37:16 PM",
+          "firstActor": "Edwin Wong",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:37:23 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:37:27 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:37:27 PM",
+          "firstActor": "Logan Ashall",
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2975,9 +671,129 @@
         "Derek Tokarski",
         "Nicole MacDonald",
         "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:38:21 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:38:25 PM",
+          "firstActor": "Laura Chambers Storey",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:38:36 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:38:39 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:38:46 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Alix Ranger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:38:50 PM",
+          "firstActor": "Alix Ranger",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:38:56 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:38:57 PM",
+          "firstActor": "Kelsey Charie",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:10 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:11 PM",
+          "firstActor": "An Tran",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:22 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:23 PM",
+          "firstActor": "Laura Chambers Storey",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:30 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:34 PM",
+          "firstActor": "Kelsey Charie",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:52 PM",
+          "firstActor": "An Tran",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:39:53 PM",
+          "firstActor": "David Townsend",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:40:04 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:40:05 PM",
+          "firstActor": "Kevin Hughes",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
       "offensePlayers": [
         "Sebastien Belanger",
         "Micheal Davidson",
@@ -2985,51 +801,1283 @@
         "David Townsend",
         "Laura Chambers Storey",
         "An Tran"
-      ],
+      ]
+    },
+    {
       "events": [
         {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:29:52 PM"
+          "timestamp": "Nov 6, 2017 8:41:00 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
         },
         {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Sebastien Belanger",
-          "timestamp": "Nov 6, 2017 9:29:53 PM"
+          "timestamp": "Nov 6, 2017 8:41:03 PM",
+          "firstActor": "Dominique Rioux",
+          "secondActor": "Nicole MacDonald",
+          "type": "PASS"
         },
         {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:29:55 PM"
+          "timestamp": "Nov 6, 2017 8:41:08 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
         },
         {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:29:57 PM"
+          "timestamp": "Nov 6, 2017 8:41:14 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
         },
         {
-          "firstActor": "Micheal Davidson",
-          "type": "PASS",
-          "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:30:01 PM"
+          "timestamp": "Nov 6, 2017 8:41:16 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
         },
         {
-          "firstActor": "David Townsend",
-          "type": "PASS",
-          "secondActor": "Micheal Davidson",
-          "timestamp": "Nov 6, 2017 9:30:05 PM"
+          "timestamp": "Nov 6, 2017 8:41:17 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
         },
         {
-          "firstActor": "Micheal Davidson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:30:06 PM"
+          "timestamp": "Nov 6, 2017 8:41:20 PM",
+          "firstActor": "Dominique Rioux",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:41:21 PM",
+          "firstActor": "Stephen Close",
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:42:05 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:09 PM",
+          "firstActor": "Thomas Sattolo",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:13 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:21 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:22 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:29 PM",
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:31 PM",
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:36 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:40 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:41 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:46 PM",
+          "firstActor": "Sebastien Belanger",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:42:47 PM",
+          "firstActor": "Kelsey Charie",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:43:07 PM",
+          "firstActor": "Kelsey Charie",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:43:11 PM",
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:43:27 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Liam Parker",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:43:30 PM",
+          "firstActor": "Liam Parker",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:43:32 PM",
+          "firstActor": "An Tran",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:43:38 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:43:39 PM",
+          "firstActor": "Laura Chambers Storey",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:44:33 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:44:44 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:44:47 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:44:54 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:44:56 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:45:03 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:45:06 PM",
+          "firstActor": "Dominique Rioux",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:45:09 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:45:12 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:45:14 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Nicole MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:45:19 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:45:19 PM",
+          "firstActor": "Jon Rowe",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:48:34 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:48:38 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:48:45 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:48:47 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:48:49 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:48:55 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:49:02 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:49:07 PM",
+          "firstActor": "Kate Achtell",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:49:10 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Alix Ranger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:49:11 PM",
+          "firstActor": "Alix Ranger",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:49:56 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:50:03 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:50:14 PM",
+          "firstActor": "Dominique Rioux",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:50:15 PM",
+          "firstActor": "Jon Rowe",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:50:55 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:50:56 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:50:59 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Alix Ranger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:51:04 PM",
+          "firstActor": "Alix Ranger",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:51:06 PM",
+          "firstActor": "Thomas Sattolo",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:51:15 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:51:16 PM",
+          "firstActor": "Sebastien Belanger",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:51:59 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:01 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:03 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:08 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:11 PM",
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:14 PM",
+          "firstActor": "Chris Sullivan",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:17 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:19 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:23 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:31 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Nicole MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:36 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:39 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:44 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Nicole MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:48 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:53 PM",
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:52:59 PM",
+          "firstActor": "Logan Ashall",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:11 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:13 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:18 PM",
+          "firstActor": "Dan Thomson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:20 PM",
+          "firstActor": "Chris Sullivan",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:22 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:23 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:26 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:31 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:37 PM",
+          "firstActor": "Dominique Rioux",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:53:37 PM",
+          "firstActor": "Stephen Close",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:54:12 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:54:17 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:09 PM",
+          "firstActor": "Thomas Sattolo",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:14 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:18 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:23 PM",
+          "firstActor": "Kate Achtell",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:27 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:30 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:37 PM",
+          "firstActor": "Kate Achtell",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:41 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:46 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:55:55 PM",
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:56:03 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:56:05 PM",
+          "firstActor": "Laura Chambers Storey",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:56:25 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:56:26 PM",
+          "firstActor": "Kate Achtell",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:57:07 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:57:08 PM",
+          "firstActor": "Dominique Rioux",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:57:12 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:57:15 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:57:21 PM",
+          "firstActor": "Logan Ashall",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:57:31 PM",
+          "firstActor": "Dominique Rioux",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:57:31 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:57:33 PM",
+          "firstActor": "Derek Tokarski",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:58:31 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:58:36 PM",
+          "firstActor": "Thomas Sattolo",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:58:43 PM",
+          "firstActor": "Kate Achtell",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:58:46 PM",
+          "firstActor": "Thomas Sattolo",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:58:52 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:58:55 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:59:00 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:59:04 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:59:10 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 8:59:11 PM",
+          "firstActor": "Kate Achtell",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 8:59:56 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:00:00 PM",
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:00:27 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:00:33 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:00:38 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:00:53 PM",
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:00:56 PM",
+          "firstActor": "Stephen Close",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:01:14 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Nicole MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:01:17 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:01:19 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Nicole MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:01:24 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:01:29 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:01:36 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:01:36 PM",
+          "firstActor": "Chris Sullivan",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:02:23 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:02:28 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:02:31 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:02:34 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:02:40 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:02:46 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:02:52 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Alix Ranger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:02:58 PM",
+          "firstActor": "Alix Ranger",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:00 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:02 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:10 PM",
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:12 PM",
+          "firstActor": "Micheal Davidson",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:15 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:15 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:17 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:18 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:22 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:31 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:33 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:03:34 PM",
+          "firstActor": "An Tran",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:04:15 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:17 PM",
+          "firstActor": "Logan Ashall",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:31 PM",
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:35 PM",
+          "firstActor": "Logan Ashall",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:45 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:48 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:51 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:53 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:55 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:58 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:04:59 PM",
+          "firstActor": "Josee Guibord",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:10:08 PM",
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:28 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:30 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Liam Parker",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:35 PM",
+          "firstActor": "Liam Parker",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:40 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:46 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:48 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:53 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:10:54 PM",
+          "firstActor": "An Tran",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
         "Kelsey Charie",
         "Thomas Sattolo",
         "Edwin Wong",
@@ -3039,6 +2087,74 @@
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:11:50 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Celine Dumais",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:11:52 PM",
+          "firstActor": "Celine Dumais",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:11:57 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:12:07 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:12:09 PM",
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:12:20 PM",
+          "firstActor": "Dominique Rioux",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:12:27 PM",
+          "firstActor": "Chris Sullivan",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:12:30 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:12:33 PM",
+          "firstActor": "Derek Tokarski",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:12:34 PM",
+          "firstActor": "Jon Rowe",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
       "offensePlayers": [
         "Logan Ashall",
         "Marcus Bordage",
@@ -3046,57 +2162,172 @@
         "Dan Thomson",
         "Celine Dumais",
         "Josee Guibord"
-      ],
+      ]
+    },
+    {
       "events": [
         {
+          "timestamp": "Nov 6, 2017 9:13:19 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Kate Achtell",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:13:24 PM",
+          "firstActor": "Kate Achtell",
+          "secondActor": "Kelsey Charie",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:13:31 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Edwin Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:13:34 PM",
+          "firstActor": "Edwin Wong",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:14:04 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:14:05 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:14:07 PM",
+          "firstActor": "An Tran",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:14:14 PM",
+          "firstActor": "Micheal Davidson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:14:17 PM",
+          "firstActor": "Kelsey Charie",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:14:19 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:14:36 PM",
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:15:02 PM",
+          "firstActor": "An Tran",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:15:08 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:15:17 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:15:17 PM",
+          "firstActor": "Micheal Davidson",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:16:04 PM",
           "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:30:53 PM"
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
         },
         {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 9:16:10 PM",
+          "firstActor": "Kevin Hughes",
           "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:30:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:16:14 PM",
           "firstActor": "Josee Guibord",
-          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:16:16 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:16:20 PM",
+          "firstActor": "Kevin Hughes",
           "secondActor": "Marcus Bordage",
-          "timestamp": "Nov 6, 2017 9:31:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:16:22 PM",
           "firstActor": "Marcus Bordage",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:31:01 PM"
-        },
-        {
-          "firstActor": "Jon Rowe",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:31:17 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:31:18 PM"
-        },
-        {
-          "firstActor": "Marcus Bordage",
-          "type": "PASS",
-          "secondActor": "Dan Thomson",
-          "timestamp": "Nov 6, 2017 9:31:28 PM"
-        },
-        {
-          "firstActor": "Dan Thomson",
-          "type": "PASS",
           "secondActor": "Josee Guibord",
-          "timestamp": "Nov 6, 2017 9:31:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:16:24 PM",
           "firstActor": "Josee Guibord",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:31:33 PM"
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:16:27 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:16:38 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Celine Dumais",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:16:39 PM",
+          "firstActor": "Celine Dumais",
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3106,78 +2337,34 @@
         "Derek Tokarski",
         "Nicole MacDonald",
         "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
       ]
     },
     {
-      "offensePlayers": [
-        "Sebastien Belanger",
-        "Micheal Davidson",
-        "Liam Parker",
-        "David Townsend",
-        "Laura Chambers Storey",
-        "An Tran"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 9:17:37 PM",
           "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "Laura Chambers Storey",
-          "timestamp": "Nov 6, 2017 9:32:21 PM"
-        },
-        {
-          "firstActor": "Laura Chambers Storey",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 9:32:23 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:32:30 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:32:32 PM"
-        },
-        {
-          "firstActor": "Kelsey Charie",
-          "type": "PASS",
-          "secondActor": "Brian Perry(S)",
-          "timestamp": "Nov 6, 2017 9:32:36 PM"
-        },
-        {
-          "firstActor": "Brian Perry(S)",
-          "type": "PASS",
-          "secondActor": "Thomas Sattolo",
-          "timestamp": "Nov 6, 2017 9:32:39 PM"
-        },
-        {
-          "firstActor": "Thomas Sattolo",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:32:45 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:32:48 PM"
-        },
-        {
-          "firstActor": "Sebastien Belanger",
-          "type": "PASS",
-          "secondActor": "An Tran",
-          "timestamp": "Nov 6, 2017 9:32:52 PM"
-        },
-        {
-          "firstActor": "An Tran",
-          "type": "PASS",
           "secondActor": "David Townsend",
-          "timestamp": "Nov 6, 2017 9:32:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:17:41 PM",
           "firstActor": "David Townsend",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:33:17 PM"
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:17:41 PM",
+          "firstActor": "An Tran",
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3187,38 +2374,843 @@
         "Brian Perry(S)",
         "Kate Achtell",
         "Alix Ranger"
+      ],
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:18:28 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:18:30 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:18:34 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:18:37 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Celine Dumais",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:18:43 PM",
+          "firstActor": "Celine Dumais",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:18:49 PM",
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:18:56 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Stephen Close",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:19:01 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Dominique Rioux",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:19:02 PM",
+          "firstActor": "Dominique Rioux",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:19:42 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:19:45 PM",
+          "firstActor": "Thomas Sattolo",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:19:52 PM",
+          "firstActor": "An Tran",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:19:54 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:20:00 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:20:05 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:20:07 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Liam Parker",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:20:08 PM",
+          "firstActor": "Liam Parker",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:20:53 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:01 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:06 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:10 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:23 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:40 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:40 PM",
+          "firstActor": "Dan Thomson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:43 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:49 PM",
+          "firstActor": "Jon Rowe",
+          "secondActor": "Derek Tokarski",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:55 PM",
+          "firstActor": "Derek Tokarski",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:22:01 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:22:03 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:22:05 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:22:13 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:22:13 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:22:15 PM",
+          "firstActor": "Dan Thomson",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:23:03 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:07 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:09 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:12 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:16 PM",
+          "firstActor": "An Tran",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:17 PM",
+          "firstActor": "Laura Chambers Storey",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:23 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Edwin Wong",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:28 PM",
+          "firstActor": "Edwin Wong",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:30 PM",
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:33 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Liam Parker",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:23:33 PM",
+          "firstActor": "Liam Parker",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:24:21 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:24:23 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:24:25 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:24:28 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:24:33 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:24:34 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:25:24 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:25:28 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "Liam Parker",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:25:31 PM",
+          "firstActor": "Liam Parker",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:25:33 PM",
+          "firstActor": "David Townsend",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:26:23 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:26:27 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:26:37 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:26:41 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:26:45 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:26:48 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:26:50 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:26:57 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:27:00 PM",
+          "firstActor": "Derek Tokarski",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:27:21 PM",
+          "firstActor": "Nicole MacDonald",
+          "secondActor": "Jon Rowe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:27:24 PM",
+          "firstActor": "Jon Rowe",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:27:39 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:27:46 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:27:53 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:27:56 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Celine Dumais",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:00 PM",
+          "firstActor": "Celine Dumais",
+          "secondActor": "Kevin Hughes",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:02 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:06 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:08 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:26 PM",
+          "firstActor": "Stephen Close",
+          "secondActor": "Chris Sullivan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:32 PM",
+          "firstActor": "Chris Sullivan",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:50 PM",
+          "firstActor": "Kevin Hughes",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:54 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:28:57 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Logan Ashall",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:29:01 PM",
+          "firstActor": "Logan Ashall",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:29:02 PM",
+          "firstActor": "Josee Guibord",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:29:52 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:29:53 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Sebastien Belanger",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:29:55 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:29:57 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:30:01 PM",
+          "firstActor": "Micheal Davidson",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:30:05 PM",
+          "firstActor": "David Townsend",
+          "secondActor": "Micheal Davidson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:30:06 PM",
+          "firstActor": "Micheal Davidson",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:30:53 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:30:56 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:31:00 PM",
+          "firstActor": "Josee Guibord",
+          "secondActor": "Marcus Bordage",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:31:01 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:31:17 PM",
+          "firstActor": "Jon Rowe",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:31:18 PM",
+          "firstActor": "Marcus Bordage",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:31:28 PM",
+          "firstActor": "Marcus Bordage",
+          "secondActor": "Dan Thomson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:31:32 PM",
+          "firstActor": "Dan Thomson",
+          "secondActor": "Josee Guibord",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:31:33 PM",
+          "firstActor": "Josee Guibord",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:32:21 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "Laura Chambers Storey",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:23 PM",
+          "firstActor": "Laura Chambers Storey",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:30 PM",
+          "firstActor": "An Tran",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:32 PM",
+          "firstActor": "Kelsey Charie",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:36 PM",
+          "firstActor": "Kelsey Charie",
+          "secondActor": "Brian Perry(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:39 PM",
+          "firstActor": "Brian Perry(S)",
+          "secondActor": "Thomas Sattolo",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:45 PM",
+          "firstActor": "Thomas Sattolo",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:48 PM",
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:52 PM",
+          "firstActor": "Sebastien Belanger",
+          "secondActor": "An Tran",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:32:59 PM",
+          "firstActor": "An Tran",
+          "secondActor": "David Townsend",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:33:17 PM",
+          "firstActor": "David Townsend",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
       ]
     }
   ],
-  "league": "ocua_17-18",
-  "teams": {
-    "home_team": [
-      "Laura Chambers Storey",
-      "Nicole MacDonald",
-      "Dominique Rioux",
-      "An Tran",
-      "Chris Sullivan",
-      "Sebastien Belanger",
-      "Stephen Close",
-      "Micheal Davidson",
-      "Liam Parker",
-      "Jon Rowe",
-      "Derek Tokarski",
-      "David Townsend"
-    ],
-    "away_team": [
-      "Kate Achtell",
-      "Celine Dumais",
-      "Josee Guibord",
-      "Alix Ranger",
-      "Logan Ashall",
-      "Marcus Bordage",
-      "Kelsey Charie",
-      "Kevin Hughes",
-      "Thomas Sattolo",
-      "Dan Thomson",
-      "Edwin Wong",
-      "Brian Perry(S)"
-    ]
-  }
+  "week": 1,
+  "homeRoster": [
+    "Laura Chambers Storey",
+    "Nicole MacDonald",
+    "Dominique Rioux",
+    "An Tran",
+    "Chris Sullivan",
+    "Sebastien Belanger",
+    "Stephen Close",
+    "Micheal Davidson",
+    "Liam Parker",
+    "Jon Rowe",
+    "Derek Tokarski",
+    "David Townsend"
+  ]
 }

--- a/data/ocua_17-18/week1_game2.json
+++ b/data/ocua_17-18/week1_game2.json
@@ -1,0 +1,3224 @@
+{
+  "score": {
+    "home_team": 23,
+    "away_team": 11
+  },
+  "week": 1,
+  "points": [
+    {
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PULL",
+          "timestamp": "Nov 6, 2017 8:25:44 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 8:25:56 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:26:00 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:26:04 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:26:08 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 8:26:10 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:26:15 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:26:21 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 8:26:23 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:26:38 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:26:43 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:26:45 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Edwin Wong",
+          "timestamp": "Nov 6, 2017 8:26:46 PM"
+        },
+        {
+          "firstActor": "Edwin Wong",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:26:50 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:26:54 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:26:58 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:27:01 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:27:05 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:27:30 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Alix Ranger",
+          "timestamp": "Nov 6, 2017 8:28:26 PM"
+        },
+        {
+          "firstActor": "Alix Ranger",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:28:27 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 8:28:38 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 8:28:39 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:28:48 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:28:55 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:29:01 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:29:09 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:29:35 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:29:40 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:29:42 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:29:46 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:29:48 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:29:51 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:29:56 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:30:03 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Liam Parker",
+          "timestamp": "Nov 6, 2017 8:30:21 PM"
+        },
+        {
+          "firstActor": "Liam Parker",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 8:30:24 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 8:30:28 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:30:29 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:31:12 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:31:18 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:31:24 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 8:31:28 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:31:33 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:31:54 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:31:57 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:32:02 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:32:04 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Celine Dumais",
+          "timestamp": "Nov 6, 2017 8:32:08 PM"
+        },
+        {
+          "firstActor": "Celine Dumais",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:32:12 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:32:17 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:32:32 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:32:36 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:32:37 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 8:33:22 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 8:33:27 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:33:27 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 8:33:32 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 8:33:35 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Liam Parker",
+          "timestamp": "Nov 6, 2017 8:33:40 PM"
+        },
+        {
+          "firstActor": "Liam Parker",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:33:41 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:34:23 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 8:34:28 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 8:34:30 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 8:34:32 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:34:36 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:34:44 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:34:48 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:34:56 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:35:00 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:35:04 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:35:08 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:35:11 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:35:17 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:35:21 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:35:27 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:35:45 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:35:49 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:35:53 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:35:55 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:36:15 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:36:18 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Edwin Wong",
+          "timestamp": "Nov 6, 2017 8:36:22 PM"
+        },
+        {
+          "firstActor": "Edwin Wong",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:36:23 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Celine Dumais",
+          "timestamp": "Nov 6, 2017 8:36:28 PM"
+        },
+        {
+          "firstActor": "Celine Dumais",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 8:36:30 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 8:36:34 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:36:38 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Celine Dumais",
+          "timestamp": "Nov 6, 2017 8:36:42 PM"
+        },
+        {
+          "firstActor": "Celine Dumais",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:36:46 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:36:48 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:36:51 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:36:56 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:36:58 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Edwin Wong",
+          "timestamp": "Nov 6, 2017 8:37:13 PM"
+        },
+        {
+          "firstActor": "Edwin Wong",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:37:16 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:37:23 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 8:37:27 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:37:27 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "events": [
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 8:38:21 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:38:25 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:38:36 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:38:39 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Alix Ranger",
+          "timestamp": "Nov 6, 2017 8:38:46 PM"
+        },
+        {
+          "firstActor": "Alix Ranger",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:38:50 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:38:56 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:38:57 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 8:39:10 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 8:39:11 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 8:39:22 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:39:23 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:39:30 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:39:34 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 8:39:52 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:39:53 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:40:04 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:40:05 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "events": [
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:41:00 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 8:41:03 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:41:08 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:41:14 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:41:16 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:41:17 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:41:20 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:41:21 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 8:42:05 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:42:09 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:42:13 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:42:21 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:42:22 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:42:29 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:42:31 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 8:42:36 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 8:42:40 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 8:42:41 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:42:46 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:42:47 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:43:07 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:43:11 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Liam Parker",
+          "timestamp": "Nov 6, 2017 8:43:27 PM"
+        },
+        {
+          "firstActor": "Liam Parker",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 8:43:30 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 8:43:32 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 8:43:38 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:43:39 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:44:33 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:44:44 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:44:47 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:44:54 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:44:56 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:45:03 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:45:06 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:45:09 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:45:12 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 8:45:14 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:45:19 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:45:19 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:48:34 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:48:38 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:48:45 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:48:47 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:48:49 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:48:55 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 8:49:02 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:49:07 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Alix Ranger",
+          "timestamp": "Nov 6, 2017 8:49:10 PM"
+        },
+        {
+          "firstActor": "Alix Ranger",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:49:11 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "events": [
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:49:56 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:50:03 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:50:14 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:50:15 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:50:55 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:50:56 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Alix Ranger",
+          "timestamp": "Nov 6, 2017 8:50:59 PM"
+        },
+        {
+          "firstActor": "Alix Ranger",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 8:51:04 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:51:06 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 8:51:15 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:51:16 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:51:59 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 8:52:01 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:52:03 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:52:08 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:52:11 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:52:14 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:52:17 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:52:19 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:52:23 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 8:52:31 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:52:36 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:52:39 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 8:52:44 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:52:48 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:52:53 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:52:59 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 8:53:11 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:53:13 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:53:18 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 8:53:20 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 8:53:22 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:53:23 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:53:26 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:53:31 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:53:37 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:53:37 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:54:12 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 8:54:17 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:55:09 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:55:14 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 8:55:18 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:55:23 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:55:27 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 8:55:30 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:55:37 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 8:55:41 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:55:46 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:55:55 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 8:56:03 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:56:05 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 8:56:25 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:56:26 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "events": [
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 8:57:07 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 8:57:08 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 8:57:12 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 8:57:15 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 8:57:21 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 8:57:31 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 8:57:31 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:57:33 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 8:58:31 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 8:58:36 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 8:58:43 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:58:46 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:58:52 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:58:55 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 8:59:00 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 8:59:04 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 8:59:10 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 8:59:11 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ],
+      "events": [
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 8:59:56 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:00:00 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:00:27 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:00:33 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:00:38 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:00:53 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:00:56 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 9:01:14 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 9:01:17 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Nicole MacDonald",
+          "timestamp": "Nov 6, 2017 9:01:19 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 9:01:24 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 9:01:29 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 9:01:36 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:01:36 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Kevin Hughes",
+        "Thomas Sattolo",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:02:23 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 9:02:28 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 9:02:31 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 9:02:34 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 9:02:40 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:02:46 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Alix Ranger",
+          "timestamp": "Nov 6, 2017 9:02:52 PM"
+        },
+        {
+          "firstActor": "Alix Ranger",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 9:02:58 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:03:00 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 9:03:02 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:03:10 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:03:12 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:03:15 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:03:15 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:03:17 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 9:03:18 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:03:22 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 9:03:31 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 9:03:33 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:03:34 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Dan Thomson",
+        "Edwin Wong",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:04:15 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:04:17 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:04:31 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:04:35 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:04:45 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:04:48 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:04:51 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:04:53 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:04:55 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:04:58 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:04:59 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:10:08 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:10:28 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Liam Parker",
+          "timestamp": "Nov 6, 2017 9:10:30 PM"
+        },
+        {
+          "firstActor": "Liam Parker",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:10:35 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:10:40 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:10:46 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 9:10:48 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 9:10:53 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:10:54 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Celine Dumais",
+          "timestamp": "Nov 6, 2017 9:11:50 PM"
+        },
+        {
+          "firstActor": "Celine Dumais",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:11:52 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:11:57 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:12:07 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:12:09 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 9:12:20 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 9:12:27 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "PASS",
+          "secondActor": "Derek Tokarski",
+          "timestamp": "Nov 6, 2017 9:12:30 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 9:12:33 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:12:34 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Kate Achtell",
+          "timestamp": "Nov 6, 2017 9:13:19 PM"
+        },
+        {
+          "firstActor": "Kate Achtell",
+          "type": "PASS",
+          "secondActor": "Kelsey Charie",
+          "timestamp": "Nov 6, 2017 9:13:24 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Edwin Wong",
+          "timestamp": "Nov 6, 2017 9:13:31 PM"
+        },
+        {
+          "firstActor": "Edwin Wong",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:13:34 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 9:14:04 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 9:14:05 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:14:07 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:14:14 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:14:17 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 9:14:19 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:14:36 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:15:02 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 9:15:08 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:15:17 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:15:17 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:16:04 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:16:10 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:16:14 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:16:16 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:16:20 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:16:22 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:16:24 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:16:27 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Celine Dumais",
+          "timestamp": "Nov 6, 2017 9:16:38 PM"
+        },
+        {
+          "firstActor": "Celine Dumais",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:16:39 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "events": [
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:17:37 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 9:17:41 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:17:41 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:18:28 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:18:30 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:18:34 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Celine Dumais",
+          "timestamp": "Nov 6, 2017 9:18:37 PM"
+        },
+        {
+          "firstActor": "Celine Dumais",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:18:43 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:18:49 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Stephen Close",
+          "timestamp": "Nov 6, 2017 9:18:56 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Dominique Rioux",
+          "timestamp": "Nov 6, 2017 9:19:01 PM"
+        },
+        {
+          "firstActor": "Dominique Rioux",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:19:02 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ],
+      "events": [
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 9:19:42 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:19:45 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:19:52 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:19:54 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:20:00 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:20:05 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Liam Parker",
+          "timestamp": "Nov 6, 2017 9:20:07 PM"
+        },
+        {
+          "firstActor": "Liam Parker",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:20:08 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:20:53 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:21:01 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:21:06 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:21:10 PM"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:20 PM",
+          "type": "DROP"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:21:23 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:21:40 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:21:40 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 9:21:43 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:21:49 PM"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:21:50 PM",
+          "type": "DROP"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:21:55 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:22:01 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:22:03 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:22:05 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:22:13 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:22:13 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:22:15 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "events": [
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:23:03 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:23:07 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:23:09 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 9:23:12 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:23:16 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:23:17 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Edwin Wong",
+          "timestamp": "Nov 6, 2017 9:23:23 PM"
+        },
+        {
+          "firstActor": "Edwin Wong",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:23:28 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:23:30 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Liam Parker",
+          "timestamp": "Nov 6, 2017 9:23:33 PM"
+        },
+        {
+          "firstActor": "Liam Parker",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:23:33 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:24:21 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:24:23 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:24:25 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:24:28 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:24:33 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:24:34 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "events": [
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:25:24 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Liam Parker",
+          "timestamp": "Nov 6, 2017 9:25:28 PM"
+        },
+        {
+          "firstActor": "Liam Parker",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:25:31 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:25:33 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:26:23 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:26:27 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:26:37 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:26:41 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:26:45 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:26:48 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:26:50 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:26:57 PM"
+        },
+        {
+          "firstActor": "Derek Tokarski",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:27:00 PM"
+        },
+        {
+          "firstActor": "Nicole MacDonald",
+          "type": "PASS",
+          "secondActor": "Jon Rowe",
+          "timestamp": "Nov 6, 2017 9:27:21 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:27:24 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:27:39 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:27:46 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:27:53 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Celine Dumais",
+          "timestamp": "Nov 6, 2017 9:27:56 PM"
+        },
+        {
+          "firstActor": "Celine Dumais",
+          "type": "PASS",
+          "secondActor": "Kevin Hughes",
+          "timestamp": "Nov 6, 2017 9:28:00 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:28:02 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:28:06 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:28:08 PM"
+        },
+        {
+          "firstActor": "Stephen Close",
+          "type": "PASS",
+          "secondActor": "Chris Sullivan",
+          "timestamp": "Nov 6, 2017 9:28:26 PM"
+        },
+        {
+          "firstActor": "Chris Sullivan",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:28:32 PM"
+        },
+        {
+          "firstActor": "Kevin Hughes",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:28:50 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:28:54 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Logan Ashall",
+          "timestamp": "Nov 6, 2017 9:28:57 PM"
+        },
+        {
+          "firstActor": "Logan Ashall",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:29:01 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:29:02 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "events": [
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:29:52 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Sebastien Belanger",
+          "timestamp": "Nov 6, 2017 9:29:53 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:29:55 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:29:57 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:30:01 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "PASS",
+          "secondActor": "Micheal Davidson",
+          "timestamp": "Nov 6, 2017 9:30:05 PM"
+        },
+        {
+          "firstActor": "Micheal Davidson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:30:06 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Logan Ashall",
+        "Marcus Bordage",
+        "Kevin Hughes",
+        "Dan Thomson",
+        "Celine Dumais",
+        "Josee Guibord"
+      ],
+      "events": [
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:30:53 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:30:56 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "PASS",
+          "secondActor": "Marcus Bordage",
+          "timestamp": "Nov 6, 2017 9:31:00 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:31:01 PM"
+        },
+        {
+          "firstActor": "Jon Rowe",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:31:17 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:31:18 PM"
+        },
+        {
+          "firstActor": "Marcus Bordage",
+          "type": "PASS",
+          "secondActor": "Dan Thomson",
+          "timestamp": "Nov 6, 2017 9:31:28 PM"
+        },
+        {
+          "firstActor": "Dan Thomson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord",
+          "timestamp": "Nov 6, 2017 9:31:32 PM"
+        },
+        {
+          "firstActor": "Josee Guibord",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:31:33 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Chris Sullivan",
+        "Stephen Close",
+        "Jon Rowe",
+        "Derek Tokarski",
+        "Nicole MacDonald",
+        "Dominique Rioux"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Sebastien Belanger",
+        "Micheal Davidson",
+        "Liam Parker",
+        "David Townsend",
+        "Laura Chambers Storey",
+        "An Tran"
+      ],
+      "events": [
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "Laura Chambers Storey",
+          "timestamp": "Nov 6, 2017 9:32:21 PM"
+        },
+        {
+          "firstActor": "Laura Chambers Storey",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 9:32:23 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:32:30 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:32:32 PM"
+        },
+        {
+          "firstActor": "Kelsey Charie",
+          "type": "PASS",
+          "secondActor": "Brian Perry(S)",
+          "timestamp": "Nov 6, 2017 9:32:36 PM"
+        },
+        {
+          "firstActor": "Brian Perry(S)",
+          "type": "PASS",
+          "secondActor": "Thomas Sattolo",
+          "timestamp": "Nov 6, 2017 9:32:39 PM"
+        },
+        {
+          "firstActor": "Thomas Sattolo",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:32:45 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:32:48 PM"
+        },
+        {
+          "firstActor": "Sebastien Belanger",
+          "type": "PASS",
+          "secondActor": "An Tran",
+          "timestamp": "Nov 6, 2017 9:32:52 PM"
+        },
+        {
+          "firstActor": "An Tran",
+          "type": "PASS",
+          "secondActor": "David Townsend",
+          "timestamp": "Nov 6, 2017 9:32:59 PM"
+        },
+        {
+          "firstActor": "David Townsend",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:33:17 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Kelsey Charie",
+        "Thomas Sattolo",
+        "Edwin Wong",
+        "Brian Perry(S)",
+        "Kate Achtell",
+        "Alix Ranger"
+      ]
+    }
+  ],
+  "league": "ocua_17-18",
+  "teams": {
+    "home_team": [
+      "Laura Chambers Storey",
+      "Nicole MacDonald",
+      "Dominique Rioux",
+      "An Tran",
+      "Chris Sullivan",
+      "Sebastien Belanger",
+      "Stephen Close",
+      "Micheal Davidson",
+      "Liam Parker",
+      "Jon Rowe",
+      "Derek Tokarski",
+      "David Townsend"
+    ],
+    "away_team": [
+      "Kate Achtell",
+      "Celine Dumais",
+      "Josee Guibord",
+      "Alix Ranger",
+      "Logan Ashall",
+      "Marcus Bordage",
+      "Kelsey Charie",
+      "Kevin Hughes",
+      "Thomas Sattolo",
+      "Dan Thomson",
+      "Edwin Wong",
+      "Brian Perry(S)"
+    ]
+  }
+}

--- a/data/ocua_17-18/week1_game3.json
+++ b/data/ocua_17-18/week1_game3.json
@@ -1,0 +1,3032 @@
+{
+  "score": {
+    "home_team": 21,
+    "away_team": 21
+  },
+  "week": 1,
+  "points": [
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PULL",
+          "timestamp": "Nov 6, 2017 9:41:59 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 9:42:18 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 9:42:19 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 9:42:23 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 9:42:25 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:42:26 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Melissa Jess",
+          "timestamp": "Nov 6, 2017 9:42:29 PM"
+        },
+        {
+          "firstActor": "Melissa Jess",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 9:42:33 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:42:37 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Stacey Wowchuk",
+          "timestamp": "Nov 6, 2017 9:42:55 PM"
+        },
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 9:42:59 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 9:43:01 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:43:02 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:43:14 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 9:43:36 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 9:43:41 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:43:46 PM"
+        },
+        {
+          "firstActor": "Melissa Jess",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:43:49 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 9:43:52 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 9:43:54 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 9:43:57 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Melissa Jess",
+          "timestamp": "Nov 6, 2017 9:44:01 PM"
+        },
+        {
+          "firstActor": "Melissa Jess",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 9:44:05 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:44:06 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 9:44:21 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:44:22 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 9:45:17 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 9:45:22 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 9:45:25 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 9:45:32 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 9:45:39 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 9:45:45 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Kristyn Berquist",
+          "timestamp": "Nov 6, 2017 9:45:50 PM"
+        },
+        {
+          "firstActor": "Kristyn Berquist",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 9:45:53 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Kristyn Berquist",
+          "timestamp": "Nov 6, 2017 9:46:00 PM"
+        },
+        {
+          "firstActor": "Kristyn Berquist",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:46:12 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 9:46:18 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 9:46:20 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 9:46:24 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 9:46:29 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:46:30 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 9:47:22 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 9:47:24 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 9:47:25 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "PASS",
+          "secondActor": "Melissa Jess",
+          "timestamp": "Nov 6, 2017 9:47:27 PM"
+        },
+        {
+          "firstActor": "Melissa Jess",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:47:28 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 9:48:29 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 9:48:34 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 9:48:37 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 9:48:41 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:48:42 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 9:49:29 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 9:49:33 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 9:49:37 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 9:49:44 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 9:49:50 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:49:51 PM"
+        },
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 9:50:21 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 9:50:24 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 9:50:28 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 9:50:41 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:50:49 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 9:51:12 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:51:12 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 9:51:17 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:51:18 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 9:51:27 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 9:51:36 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:51:37 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 9:52:31 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 9:52:37 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:52:44 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 9:53:00 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 9:53:08 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 9:53:10 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 9:53:12 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 9:53:17 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 9:53:22 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 9:53:27 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 9:53:35 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 9:53:42 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 9:53:53 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:53:59 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:54:02 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 9:54:13 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:54:13 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 9:55:07 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 9:55:08 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 9:55:18 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:55:19 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 9:56:18 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 9:56:25 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 9:56:32 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 9:56:40 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 9:56:48 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 9:56:51 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 9:57:00 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Kristyn Berquist",
+          "timestamp": "Nov 6, 2017 9:57:04 PM"
+        },
+        {
+          "firstActor": "Kristyn Berquist",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:57:06 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 9:57:54 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 9:57:58 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 9:58:00 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 9:58:02 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 9:58:04 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 9:58:05 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 9:58:09 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 9:58:14 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 9:58:20 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:58:21 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 9:59:02 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 9:59:08 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 9:59:09 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 10:00:08 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:00:14 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:00:19 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:00:23 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:00:24 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 10:00:26 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:00:32 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:00:47 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:00:53 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:00:56 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:00:57 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:00:58 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:01:10 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 10:01:40 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:01:44 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:01:47 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:01:52 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:01:56 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:02:02 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:02:02 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Ken Maclean",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:02:56 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:03:00 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:03:46 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:03:46 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:04:31 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 10:04:38 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:04:41 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 10:04:42 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:04:44 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:04:48 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:04:48 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:05:39 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:05:44 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:05:47 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:05:48 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:06:40 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:06:43 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:06:45 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:07:33 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:07:35 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:07:39 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:07:41 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:07:48 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:07:51 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:07:56 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:07:59 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:08:00 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Melissa Jess",
+          "timestamp": "Nov 6, 2017 10:09:02 PM"
+        },
+        {
+          "firstActor": "Melissa Jess",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 10:09:06 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:09:06 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:10:02 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 10:10:07 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:10:08 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:10:16 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Stacey Wowchuk",
+          "timestamp": "Nov 6, 2017 10:10:17 PM"
+        },
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:10:18 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:11:30 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:11:34 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:11:36 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Richard Gregory",
+          "timestamp": "Nov 6, 2017 10:11:39 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 10:11:42 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:11:47 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:11:48 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:12:01 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:12:10 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:12:32 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:12:33 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 10:13:19 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:13:23 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:13:34 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:13:40 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 10:13:42 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:13:47 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:13:54 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:13:58 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:13:59 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:14:52 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:14:57 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 10:15:06 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:15:09 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:15:16 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:15:16 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:21:38 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:21:44 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:21:54 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 10:22:00 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:22:03 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:22:11 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:22:12 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:22:18 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:22:19 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:22:34 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:22:41 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:22:43 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:22:44 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Ken Maclean",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:23:37 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:23:42 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:23:46 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:23:50 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:23:51 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:25:00 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:25:03 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:25:24 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:25:32 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:25:52 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:25:55 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:25:59 PM"
+        },
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:26:18 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:26:19 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:26:33 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:26:33 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Ken Maclean",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 10:27:30 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:27:40 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:27:41 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:28:32 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:28:41 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:28:43 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:28:50 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:28:55 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:28:56 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:29:09 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Kristyn Berquist",
+          "timestamp": "Nov 6, 2017 10:29:15 PM"
+        },
+        {
+          "firstActor": "Kristyn Berquist",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:29:16 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:30:15 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 10:30:22 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:30:28 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:30:29 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:30:41 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:31:27 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:31:31 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 10:31:35 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:31:38 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:31:39 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:32:44 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:32:49 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:32:51 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:32:54 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:32:58 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:33:01 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:33:03 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:33:04 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:33:58 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:34:01 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:34:04 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:34:12 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:34:17 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:34:25 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:34:27 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:34:28 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:34:29 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Melissa Jess",
+          "timestamp": "Nov 6, 2017 10:35:17 PM"
+        },
+        {
+          "firstActor": "Melissa Jess",
+          "type": "PASS",
+          "secondActor": "Michael Colantonio",
+          "timestamp": "Nov 6, 2017 10:35:23 PM"
+        },
+        {
+          "firstActor": "Michael Colantonio",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:35:24 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:35:26 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:35:30 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:35:36 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:35:49 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:35:54 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:36:01 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:37:10 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:37:15 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:37:23 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 10:37:27 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:37:30 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:37:48 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:37:49 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Stacey Wowchuk",
+          "timestamp": "Nov 6, 2017 10:38:39 PM"
+        },
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:38:44 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:38:46 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:38:50 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:38:52 PM"
+        },
+        {
+          "firstActor": "Richard Gregory",
+          "type": "PASS",
+          "secondActor": "Justine Price",
+          "timestamp": "Nov 6, 2017 10:39:01 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:39:02 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:39:49 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:39:50 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:39:55 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:39:58 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:40:00 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:40:07 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:40:21 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:40:24 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:40:31 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:40:36 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 10:40:42 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:40:44 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Kristyn Berquist",
+          "timestamp": "Nov 6, 2017 10:40:46 PM"
+        },
+        {
+          "firstActor": "Kristyn Berquist",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:40:47 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:41:36 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:41:45 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:41:53 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:41:54 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 10:42:55 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:43:01 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:43:04 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:43:56 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:43:59 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:44:03 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:44:07 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:44:13 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:44:23 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:44:23 PM"
+        },
+        {
+          "firstActor": "Justine Price",
+          "type": "PASS",
+          "secondActor": "Tom Newman",
+          "timestamp": "Nov 6, 2017 10:44:34 PM"
+        },
+        {
+          "firstActor": "Tom Newman",
+          "type": "PASS",
+          "secondActor": "Melissa Jess",
+          "timestamp": "Nov 6, 2017 10:44:37 PM"
+        },
+        {
+          "firstActor": "Melissa Jess",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:44:37 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "events": [
+        {
+          "firstActor": "Jaime Boss",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:45:31 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:45:38 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:45:47 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:45:49 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:46:29 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:46:46 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:46:48 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Wing-Leung Chan",
+          "timestamp": "Nov 6, 2017 10:46:51 PM"
+        },
+        {
+          "firstActor": "Wing-Leung Chan",
+          "type": "PASS",
+          "secondActor": "Frederic Caron",
+          "timestamp": "Nov 6, 2017 10:46:57 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:46:59 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:47:20 PM"
+        },
+        {
+          "firstActor": "Frederic Caron",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:47:24 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:47:50 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:47:50 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:48:41 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:48:49 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Stacey Wowchuk",
+          "timestamp": "Nov 6, 2017 10:48:51 PM"
+        },
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:48:55 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:49:06 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Ken Maclean",
+          "timestamp": "Nov 6, 2017 10:49:09 PM"
+        },
+        {
+          "firstActor": "Ken Maclean",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:49:13 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Nick Theriault",
+          "timestamp": "Nov 6, 2017 10:49:18 PM"
+        },
+        {
+          "firstActor": "Nick Theriault",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:49:19 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:50:01 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:50:06 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Kristyn Berquist",
+          "timestamp": "Nov 6, 2017 10:50:09 PM"
+        },
+        {
+          "firstActor": "Kristyn Berquist",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:50:13 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:50:14 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:50:18 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:50:22 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:50:24 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:50:29 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:50:36 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:50:41 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:50:44 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:50:49 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:50:56 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:50:57 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
+      ],
+      "events": [
+        {
+          "firstActor": "Richard Gregory",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:52:02 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Jaime Boss",
+          "timestamp": "Nov 6, 2017 10:52:09 PM"
+        },
+        {
+          "firstActor": "Jaime Boss",
+          "type": "PASS",
+          "secondActor": "Jonathan Pindur",
+          "timestamp": "Nov 6, 2017 10:52:11 PM"
+        },
+        {
+          "firstActor": "Jonathan Pindur",
+          "type": "PASS",
+          "secondActor": "Simon Berry",
+          "timestamp": "Nov 6, 2017 10:52:17 PM"
+        },
+        {
+          "firstActor": "Simon Berry",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:52:19 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:52:20 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "events": [
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:53:18 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:53:21 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "PASS",
+          "secondActor": "Cassie Berquist",
+          "timestamp": "Nov 6, 2017 10:53:26 PM"
+        },
+        {
+          "firstActor": "Cassie Berquist",
+          "type": "PASS",
+          "secondActor": "Nicholas Aghajanian",
+          "timestamp": "Nov 6, 2017 10:53:29 PM"
+        },
+        {
+          "firstActor": "Nicholas Aghajanian",
+          "type": "PASS",
+          "secondActor": "Scott Higgins",
+          "timestamp": "Nov 6, 2017 10:53:33 PM"
+        },
+        {
+          "firstActor": "Scott Higgins",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:53:37 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:53:38 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:53:57 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:54:03 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "PASS",
+          "secondActor": "Jim Robinson",
+          "timestamp": "Nov 6, 2017 10:54:07 PM"
+        },
+        {
+          "firstActor": "Jim Robinson",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:54:08 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Geofford Seaborn",
+          "timestamp": "Nov 6, 2017 10:54:10 PM"
+        },
+        {
+          "firstActor": "Geofford Seaborn",
+          "type": "PASS",
+          "secondActor": "Stacey Wowchuk",
+          "timestamp": "Nov 6, 2017 10:54:14 PM"
+        },
+        {
+          "firstActor": "Stacey Wowchuk",
+          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "timestamp": "Nov 6, 2017 10:54:17 PM"
+        },
+        {
+          "firstActor": "Alessandro Colantonio",
+          "type": "PASS",
+          "secondActor": "Andrea Proulx(S)",
+          "timestamp": "Nov 6, 2017 10:54:22 PM"
+        },
+        {
+          "firstActor": "Andrea Proulx(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:54:23 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
+      ]
+    }
+  ],
+  "league": "ocua_17-18",
+  "teams": {
+    "home_team": [
+      "Cassie Berquist",
+      "Kristyn Berquist",
+      "Melissa Jess",
+      "Justine Price",
+      "Nicholas Aghajanian",
+      "Frederic Caron",
+      "Wing-Leung Chan",
+      "Michael Colantonio",
+      "Richard Gregory",
+      "Scott Higgins",
+      "Tom Newman",
+      "Darryl Payne"
+    ],
+    "away_team": [
+      "Jaime Boss",
+      "Stacey Wowchuk",
+      "Andrea Proulx(S)",
+      "Alessandro Colantonio",
+      "Simon Berry",
+      "Ken Maclean",
+      "Jonathan Pindur",
+      "Jim Robinson",
+      "Geofford Seaborn",
+      "Nick Theriault"
+    ]
+  }
+}

--- a/data/ocua_17-18/week1_game3.json
+++ b/data/ocua_17-18/week1_game3.json
@@ -1,166 +1,170 @@
 {
-  "score": {
-    "home_team": 21,
-    "away_team": 21
-  },
-  "week": 1,
+  "awayRoster": [
+    "Jaime Boss",
+    "Stacey Wowchuk",
+    "Andrea Proulx(S)",
+    "Alessandro Colantonio",
+    "Simon Berry",
+    "Ken Maclean",
+    "Jonathan Pindur",
+    "Jim Robinson",
+    "Geofford Seaborn",
+    "Nick Theriault"
+  ],
+  "awayTeam": "The Sticklers (Forced Jokes and Dadpuns) (Sticks)",
+  "homeTeam": "Strike",
+  "awayScore": 21,
+  "league": "ocua_17-18",
+  "homeScore": 21,
   "points": [
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Simon Berry",
-        "Jim Robinson",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 9:41:59 PM",
           "firstActor": "Scott Higgins",
-          "type": "PULL",
-          "timestamp": "Nov 6, 2017 9:41:59 PM"
+          "type": "PULL"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:18 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 9:42:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:19 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 9:42:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:23 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 9:42:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:25 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 9:42:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:26 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:42:26 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:29 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Melissa Jess",
-          "timestamp": "Nov 6, 2017 9:42:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:33 PM",
           "firstActor": "Melissa Jess",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 9:42:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:37 PM",
           "firstActor": "Tom Newman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:42:37 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:55 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Stacey Wowchuk",
-          "timestamp": "Nov 6, 2017 9:42:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:42:59 PM",
           "firstActor": "Stacey Wowchuk",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 9:42:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:01 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 9:43:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:02 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:43:02 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:14 PM",
           "firstActor": "Justine Price",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:43:14 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:36 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 9:43:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:41 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 9:43:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:46 PM",
           "firstActor": "Jim Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:43:46 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:49 PM",
           "firstActor": "Melissa Jess",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:43:49 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:52 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 9:43:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:54 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 9:43:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:43:57 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 9:43:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:44:01 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Melissa Jess",
-          "timestamp": "Nov 6, 2017 9:44:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:44:05 PM",
           "firstActor": "Melissa Jess",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 9:44:05 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:44:06 PM",
           "firstActor": "Tom Newman",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:44:06 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 9:44:21 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 9:44:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:44:22 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:44:22 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -170,105 +174,105 @@
         "Tom Newman",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Darryl Payne",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 9:45:17 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 9:45:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:45:22 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 9:45:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:45:25 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 9:45:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:45:32 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 9:45:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:45:39 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 9:45:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:45:45 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 9:45:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:45:50 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Kristyn Berquist",
-          "timestamp": "Nov 6, 2017 9:45:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:45:53 PM",
           "firstActor": "Kristyn Berquist",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 9:45:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:46:00 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Kristyn Berquist",
-          "timestamp": "Nov 6, 2017 9:46:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:46:12 PM",
           "firstActor": "Kristyn Berquist",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:46:12 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 9:46:18 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 9:46:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:46:20 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 9:46:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:46:24 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 9:46:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:46:29 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 9:46:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:46:30 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:46:30 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -278,98 +282,8 @@
         "Geofford Seaborn",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
-      ]
-    },
-    {
+      ],
       "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Scott Higgins",
-        "Tom Newman",
-        "Melissa Jess",
-        "Justine Price"
-      ],
-      "events": [
-        {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 9:47:22 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 9:47:24 PM"
-        },
-        {
-          "firstActor": "Tom Newman",
-          "type": "PASS",
-          "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 9:47:25 PM"
-        },
-        {
-          "firstActor": "Michael Colantonio",
-          "type": "PASS",
-          "secondActor": "Melissa Jess",
-          "timestamp": "Nov 6, 2017 9:47:27 PM"
-        },
-        {
-          "firstActor": "Melissa Jess",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:47:28 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Simon Berry",
-        "Ken Maclean",
-        "Jim Robinson",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Andrea Proulx(S)"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
-      "events": [
-        {
-          "firstActor": "Geofford Seaborn",
-          "type": "PASS",
-          "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 9:48:29 PM"
-        },
-        {
-          "firstActor": "Jaime Boss",
-          "type": "PASS",
-          "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 9:48:34 PM"
-        },
-        {
-          "firstActor": "Nick Theriault",
-          "type": "PASS",
-          "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 9:48:37 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 9:48:41 PM"
-        },
-        {
-          "firstActor": "Jonathan Pindur",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:48:42 PM"
-        }
-      ],
-      "defensePlayers": [
         "Nicholas Aghajanian",
         "Frederic Caron",
         "Wing-Leung Chan",
@@ -379,6 +293,45 @@
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:47:22 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:47:24 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Tom Newman",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:47:25 PM",
+          "firstActor": "Tom Newman",
+          "secondActor": "Michael Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:47:27 PM",
+          "firstActor": "Michael Colantonio",
+          "secondActor": "Melissa Jess",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:47:28 PM",
+          "firstActor": "Melissa Jess",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ],
       "offensePlayers": [
         "Michael Colantonio",
         "Richard Gregory",
@@ -386,110 +339,161 @@
         "Tom Newman",
         "Melissa Jess",
         "Justine Price"
-      ],
+      ]
+    },
+    {
       "events": [
         {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 9:49:29 PM"
+          "timestamp": "Nov 6, 2017 9:48:29 PM",
+          "firstActor": "Geofford Seaborn",
+          "secondActor": "Jaime Boss",
+          "type": "PASS"
         },
         {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 9:49:33 PM"
+          "timestamp": "Nov 6, 2017 9:48:34 PM",
+          "firstActor": "Jaime Boss",
+          "secondActor": "Nick Theriault",
+          "type": "PASS"
         },
         {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 9:49:37 PM"
+          "timestamp": "Nov 6, 2017 9:48:37 PM",
+          "firstActor": "Nick Theriault",
+          "secondActor": "Alessandro Colantonio",
+          "type": "PASS"
         },
         {
-          "firstActor": "Justine Price",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 9:49:44 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 9:49:50 PM"
-        },
-        {
-          "firstActor": "Richard Gregory",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:49:51 PM"
-        },
-        {
-          "firstActor": "Stacey Wowchuk",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 9:50:21 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 9:48:41 PM",
+          "firstActor": "Alessandro Colantonio",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 9:50:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:48:42 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:49:29 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Richard Gregory",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:49:33 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:49:37 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Justine Price",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:49:44 PM",
+          "firstActor": "Justine Price",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:49:50 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Richard Gregory",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:49:51 PM",
+          "firstActor": "Richard Gregory",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:50:21 PM",
+          "firstActor": "Stacey Wowchuk",
+          "secondActor": "Andrea Proulx(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:50:24 PM",
+          "firstActor": "Andrea Proulx(S)",
+          "secondActor": "Jonathan Pindur",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:50:28 PM",
+          "firstActor": "Jonathan Pindur",
           "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 9:50:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:50:41 PM",
           "firstActor": "Ken Maclean",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 9:50:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:50:49 PM",
           "firstActor": "Jim Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:50:49 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 9:51:12 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 9:51:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:51:12 PM",
           "firstActor": "Justine Price",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:51:12 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 9:51:17 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 9:51:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:51:18 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:51:18 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 9:51:27 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 9:51:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:51:36 PM",
           "firstActor": "Justine Price",
-          "type": "PASS",
           "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 9:51:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:51:37 PM",
           "firstActor": "Michael Colantonio",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:51:37 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -499,115 +503,115 @@
         "Jim Robinson",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Jim Robinson",
-        "Geofford Seaborn",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 9:52:31 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 9:52:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:52:37 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 9:52:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:52:44 PM",
           "firstActor": "Nick Theriault",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:52:44 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:00 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 9:53:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:08 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 9:53:08 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:10 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 9:53:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:12 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 9:53:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:17 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 9:53:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:22 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 9:53:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:27 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 9:53:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:35 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 9:53:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:42 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 9:53:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:53 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 9:53:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:53:59 PM",
           "firstActor": "Frederic Caron",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:53:59 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 9:54:02 PM",
           "firstActor": "Nick Theriault",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:54:02 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 9:54:13 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 9:54:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:54:13 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:54:13 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -617,39 +621,39 @@
         "Darryl Payne",
         "Cassie Berquist",
         "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Scott Higgins",
-        "Tom Newman",
-        "Melissa Jess",
-        "Justine Price"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 9:55:07 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 9:55:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:55:08 PM",
           "firstActor": "Michael Colantonio",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 9:55:08 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 9:55:18 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 9:55:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:55:19 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:55:19 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -659,70 +663,70 @@
         "Geofford Seaborn",
         "Jaime Boss",
         "Stacey Wowchuk"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Darryl Payne",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 9:56:18 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 9:56:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:56:25 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 9:56:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:56:32 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 9:56:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:56:40 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 9:56:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:56:48 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 9:56:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:56:51 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 9:56:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:57:00 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 9:57:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:57:04 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Kristyn Berquist",
-          "timestamp": "Nov 6, 2017 9:57:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:57:06 PM",
           "firstActor": "Kristyn Berquist",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:57:06 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -732,114 +736,8 @@
         "Nick Theriault",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
-      ]
-    },
-    {
+      ],
       "offensePlayers": [
-        "Alessandro Colantonio",
-        "Ken Maclean",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Jaime Boss",
-        "Andrea Proulx(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 9:57:54 PM"
-        },
-        {
-          "firstActor": "Jonathan Pindur",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 9:57:58 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 9:58:00 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 9:58:02 PM"
-        },
-        {
-          "firstActor": "Tom Newman",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 9:58:04 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 9:58:05 PM"
-        },
-        {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 9:58:09 PM"
-        },
-        {
-          "firstActor": "Michael Colantonio",
-          "type": "PASS",
-          "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 9:58:14 PM"
-        },
-        {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 9:58:20 PM"
-        },
-        {
-          "firstActor": "Justine Price",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:58:21 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Scott Higgins",
-        "Tom Newman",
-        "Melissa Jess",
-        "Justine Price"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Simon Berry",
-        "Ken Maclean",
-        "Jim Robinson",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
-      "events": [
-        {
-          "firstActor": "Jaime Boss",
-          "type": "PASS",
-          "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 9:59:02 PM"
-        },
-        {
-          "firstActor": "Nick Theriault",
-          "type": "PASS",
-          "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 9:59:08 PM"
-        },
-        {
-          "firstActor": "Simon Berry",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 9:59:09 PM"
-        }
-      ],
-      "defensePlayers": [
         "Nicholas Aghajanian",
         "Frederic Caron",
         "Wing-Leung Chan",
@@ -849,7 +747,66 @@
       ]
     },
     {
-      "offensePlayers": [
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 9:57:54 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Jonathan Pindur",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:57:58 PM",
+          "firstActor": "Jonathan Pindur",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:00 PM",
+          "firstActor": "Scott Higgins",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:02 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Tom Newman",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:04 PM",
+          "firstActor": "Tom Newman",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:05 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Richard Gregory",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:09 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Michael Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:14 PM",
+          "firstActor": "Michael Colantonio",
+          "secondActor": "Richard Gregory",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:20 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Justine Price",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 9:58:21 PM",
+          "firstActor": "Justine Price",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
         "Michael Colantonio",
         "Richard Gregory",
         "Scott Higgins",
@@ -857,119 +814,166 @@
         "Melissa Jess",
         "Justine Price"
       ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
       "events": [
         {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 10:00:08 PM"
-        },
-        {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:00:14 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:00:19 PM"
-        },
-        {
-          "firstActor": "Justine Price",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:00:23 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:00:24 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 9:59:02 PM",
+          "firstActor": "Jaime Boss",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 10:00:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 9:59:08 PM",
           "firstActor": "Nick Theriault",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:00:32 PM"
+          "secondActor": "Simon Berry",
+          "type": "PASS"
         },
         {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:00:47 PM"
-        },
+          "timestamp": "Nov 6, 2017 9:59:09 PM",
+          "firstActor": "Simon Berry",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ]
+    },
+    {
+      "events": [
         {
-          "firstActor": "Justine Price",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:00:53 PM"
-        },
-        {
-          "firstActor": "Nick Theriault",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:00:56 PM"
-        },
-        {
-          "firstActor": "Nick Theriault",
-          "type": "PASS",
-          "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:00:57 PM"
-        },
-        {
-          "firstActor": "Jonathan Pindur",
-          "type": "PASS",
-          "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:00:58 PM"
-        },
-        {
-          "firstActor": "Jim Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:01:10 PM"
-        },
-        {
-          "firstActor": "Tom Newman",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 10:00:08 PM",
+          "firstActor": "Scott Higgins",
           "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 10:01:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:00:14 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:01:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:00:19 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:01:47 PM"
-        },
-        {
-          "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:01:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:00:23 PM",
           "firstActor": "Justine Price",
-          "type": "PASS",
-          "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:01:56 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:00:24 PM",
+          "firstActor": "Alessandro Colantonio",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:00:26 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Nick Theriault",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:00:32 PM",
+          "firstActor": "Nick Theriault",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:00:47 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Justine Price",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:00:53 PM",
+          "firstActor": "Justine Price",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:00:56 PM",
+          "firstActor": "Nick Theriault",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:00:57 PM",
+          "firstActor": "Nick Theriault",
+          "secondActor": "Jonathan Pindur",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:00:58 PM",
+          "firstActor": "Jonathan Pindur",
+          "secondActor": "Jim Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:01:10 PM",
+          "firstActor": "Jim Robinson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:01:40 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:02:02 PM"
+          "secondActor": "Richard Gregory",
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:01:44 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:01:47 PM",
           "firstActor": "Scott Higgins",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:02:02 PM"
+          "secondActor": "Tom Newman",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:01:52 PM",
+          "firstActor": "Tom Newman",
+          "secondActor": "Justine Price",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:01:56 PM",
+          "firstActor": "Justine Price",
+          "secondActor": "Tom Newman",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:02:02 PM",
+          "firstActor": "Tom Newman",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:02:02 PM",
+          "firstActor": "Scott Higgins",
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -979,40 +983,40 @@
         "Nick Theriault",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Simon Berry",
-        "Ken Maclean",
-        "Geofford Seaborn",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:02:56 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:02:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:03:00 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:03:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:03:46 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:03:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:03:46 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:03:46 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1022,58 +1026,58 @@
         "Darryl Payne",
         "Cassie Berquist",
         "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Ken Maclean",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Stacey Wowchuk"
       ]
     },
     {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Scott Higgins",
-        "Tom Newman",
-        "Melissa Jess",
-        "Justine Price"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:04:31 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:04:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:04:38 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 10:04:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:04:41 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:04:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:04:42 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 10:04:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:04:44 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:04:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:04:48 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:04:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:04:48 PM",
           "firstActor": "Tom Newman",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:04:48 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1083,40 +1087,40 @@
         "Nick Theriault",
         "Jaime Boss",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Simon Berry",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Stacey Wowchuk",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:05:39 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:05:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:05:44 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:05:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:05:47 PM",
           "firstActor": "Simon Berry",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:05:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:05:48 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:05:48 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1126,199 +1130,199 @@
         "Darryl Payne",
         "Cassie Berquist",
         "Kristyn Berquist"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Scott Higgins",
-        "Tom Newman",
-        "Melissa Jess",
-        "Justine Price"
       ],
-      "events": [
-        {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:06:40 PM"
-        },
-        {
-          "firstActor": "Justine Price",
-          "type": "PASS",
-          "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:06:43 PM"
-        },
-        {
-          "firstActor": "Tom Newman",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:06:45 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Simon Berry",
-        "Ken Maclean",
-        "Jim Robinson",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ]
-    },
-    {
       "offensePlayers": [
         "Alessandro Colantonio",
-        "Ken Maclean",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Jaime Boss",
-        "Andrea Proulx(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Jaime Boss",
-          "type": "PASS",
-          "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:07:33 PM"
-        },
-        {
-          "firstActor": "Ken Maclean",
-          "type": "PASS",
-          "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:07:35 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:07:39 PM"
-        },
-        {
-          "firstActor": "Jaime Boss",
-          "type": "PASS",
-          "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:07:41 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:07:48 PM"
-        },
-        {
-          "firstActor": "Ken Maclean",
-          "type": "PASS",
-          "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:07:51 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:07:56 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
-          "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:07:59 PM"
-        },
-        {
-          "firstActor": "Ken Maclean",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:08:00 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Darryl Payne",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Scott Higgins",
-        "Tom Newman",
-        "Melissa Jess",
-        "Justine Price"
-      ],
-      "events": [
-        {
-          "firstActor": "Richard Gregory",
-          "type": "PASS",
-          "secondActor": "Melissa Jess",
-          "timestamp": "Nov 6, 2017 10:09:02 PM"
-        },
-        {
-          "firstActor": "Melissa Jess",
-          "type": "PASS",
-          "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 10:09:06 PM"
-        },
-        {
-          "firstActor": "Michael Colantonio",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:09:06 PM"
-        }
-      ],
-      "defensePlayers": [
         "Simon Berry",
-        "Jim Robinson",
-        "Geofford Seaborn",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Ken Maclean",
         "Jonathan Pindur",
-        "Nick Theriault",
+        "Geofford Seaborn",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
-      ],
+      ]
+    },
+    {
       "events": [
         {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:10:02 PM"
+          "timestamp": "Nov 6, 2017 10:06:40 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Justine Price",
+          "type": "PASS"
         },
         {
-          "firstActor": "Jonathan Pindur",
-          "type": "PASS",
-          "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 10:10:07 PM"
+          "timestamp": "Nov 6, 2017 10:06:43 PM",
+          "firstActor": "Justine Price",
+          "secondActor": "Tom Newman",
+          "type": "PASS"
         },
         {
-          "firstActor": "Nick Theriault",
-          "type": "PASS",
-          "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:10:08 PM"
-        },
+          "timestamp": "Nov 6, 2017 10:06:45 PM",
+          "firstActor": "Tom Newman",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "events": [
         {
-          "firstActor": "Jonathan Pindur",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 10:07:33 PM",
+          "firstActor": "Jaime Boss",
           "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:10:16 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:07:35 PM",
           "firstActor": "Ken Maclean",
-          "type": "PASS",
+          "secondActor": "Alessandro Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:07:39 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Jaime Boss",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:07:41 PM",
+          "firstActor": "Jaime Boss",
+          "secondActor": "Alessandro Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:07:48 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Ken Maclean",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:07:51 PM",
+          "firstActor": "Ken Maclean",
+          "secondActor": "Alessandro Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:07:56 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Andrea Proulx(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:07:59 PM",
+          "firstActor": "Andrea Proulx(S)",
+          "secondActor": "Ken Maclean",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:08:00 PM",
+          "firstActor": "Ken Maclean",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Darryl Payne",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:09:02 PM",
+          "firstActor": "Richard Gregory",
+          "secondActor": "Melissa Jess",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:09:06 PM",
+          "firstActor": "Melissa Jess",
+          "secondActor": "Michael Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:09:06 PM",
+          "firstActor": "Michael Colantonio",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Simon Berry",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Scott Higgins",
+        "Tom Newman",
+        "Melissa Jess",
+        "Justine Price"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:10:02 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Jonathan Pindur",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:10:07 PM",
+          "firstActor": "Jonathan Pindur",
+          "secondActor": "Nick Theriault",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:10:08 PM",
+          "firstActor": "Nick Theriault",
+          "secondActor": "Jonathan Pindur",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:10:16 PM",
+          "firstActor": "Jonathan Pindur",
+          "secondActor": "Ken Maclean",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:10:17 PM",
+          "firstActor": "Ken Maclean",
           "secondActor": "Stacey Wowchuk",
-          "timestamp": "Nov 6, 2017 10:10:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:18 PM",
           "firstActor": "Stacey Wowchuk",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:10:18 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1328,80 +1332,80 @@
         "Darryl Payne",
         "Cassie Berquist",
         "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Tom Newman",
-        "Darryl Payne",
-        "Melissa Jess",
-        "Justine Price"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:11:30 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:11:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:34 PM",
           "firstActor": "Justine Price",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:11:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:36 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:11:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:39 PM",
           "firstActor": "Justine Price",
-          "type": "PASS",
           "secondActor": "Richard Gregory",
-          "timestamp": "Nov 6, 2017 10:11:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:42 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 10:11:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:47 PM",
           "firstActor": "Michael Colantonio",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:11:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:48 PM",
           "firstActor": "Tom Newman",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:11:48 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:01 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:12:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:10 PM",
           "firstActor": "Simon Berry",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:12:10 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:32 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:12:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:33 PM",
           "firstActor": "Tom Newman",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:12:33 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1411,69 +1415,69 @@
         "Geofford Seaborn",
         "Jaime Boss",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Simon Berry",
-        "Ken Maclean",
-        "Jonathan Pindur",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:13:19 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 10:13:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:23 PM",
           "firstActor": "Nick Theriault",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:13:23 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:34 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:13:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:40 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:13:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:42 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 10:13:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:47 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:13:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:54 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:13:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:58 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:13:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:59 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:13:59 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1483,51 +1487,51 @@
         "Scott Higgins",
         "Cassie Berquist",
         "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Jonathan Pindur",
-        "Jim Robinson",
-        "Geofford Seaborn",
-        "Stacey Wowchuk",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:14:52 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:14:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:57 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:14:57 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:15:06 PM",
           "firstActor": "Justine Price",
-          "type": "PASS",
           "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 10:15:06 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:15:09 PM",
           "firstActor": "Michael Colantonio",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:15:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:15:16 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:15:16 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:15:16 PM",
           "firstActor": "Justine Price",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:15:16 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1537,92 +1541,92 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:21:38 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:21:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:21:44 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:21:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:21:54 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:21:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:00 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 10:22:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:03 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:22:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:11 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:22:11 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:12 PM",
           "firstActor": "Cassie Berquist",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:22:12 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:18 PM",
           "firstActor": "Ken Maclean",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:22:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:19 PM",
           "firstActor": "Simon Berry",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:22:19 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:34 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:22:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:41 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:22:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:43 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:22:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:22:44 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:22:44 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1632,46 +1636,46 @@
         "Nick Theriault",
         "Jaime Boss",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Jonathan Pindur",
-        "Jim Robinson",
-        "Geofford Seaborn",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:23:37 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:23:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:23:42 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:23:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:23:46 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:23:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:23:50 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:23:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:23:51 PM",
           "firstActor": "Jim Robinson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:23:51 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1681,77 +1685,77 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:25:00 PM",
           "firstActor": "Scott Higgins",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:25:00 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:25:03 PM",
           "firstActor": "Simon Berry",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:25:03 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:25:24 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:25:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:25:32 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:25:32 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:25:52 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:25:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:25:55 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:25:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:25:59 PM",
           "firstActor": "Cassie Berquist",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:25:59 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:26:18 PM",
           "firstActor": "Stacey Wowchuk",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:26:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:26:19 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:26:19 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:26:33 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:26:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:26:33 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:26:33 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1761,34 +1765,34 @@
         "Geofford Seaborn",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Jonathan Pindur",
-        "Jim Robinson",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:27:30 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 10:27:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:27:40 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:27:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:27:41 PM",
           "firstActor": "Jim Robinson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:27:41 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1798,67 +1802,67 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Jonathan Pindur",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:28:32 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:28:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:28:41 PM",
           "firstActor": "Cassie Berquist",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:28:41 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:28:43 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:28:43 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:28:50 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:28:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:28:55 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:28:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:28:56 PM",
           "firstActor": "Jaime Boss",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:28:56 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:29:09 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:29:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:29:15 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Kristyn Berquist",
-          "timestamp": "Nov 6, 2017 10:29:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:29:16 PM",
           "firstActor": "Kristyn Berquist",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:29:16 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1868,45 +1872,45 @@
         "Geofford Seaborn",
         "Jaime Boss",
         "Stacey Wowchuk"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Simon Berry",
-        "Jim Robinson",
-        "Nick Theriault",
-        "Stacey Wowchuk",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:30:15 PM",
           "firstActor": "Stacey Wowchuk",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:30:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:30:22 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 10:30:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:30:28 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:30:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:30:29 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:30:29 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:30:41 PM",
           "firstActor": "Tom Newman",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:30:41 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1916,46 +1920,46 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Ken Maclean",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:31:27 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:31:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:31:31 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:31:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:31:35 PM",
           "firstActor": "Ken Maclean",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 10:31:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:31:38 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:31:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:31:39 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:31:39 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1965,62 +1969,62 @@
         "Scott Higgins",
         "Cassie Berquist",
         "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Tom Newman",
-        "Darryl Payne",
-        "Melissa Jess",
-        "Justine Price"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:32:44 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:32:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:32:49 PM",
           "firstActor": "Justine Price",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:32:49 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:32:51 PM",
           "firstActor": "Jaime Boss",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:32:51 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:32:54 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:32:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:32:58 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:32:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:33:01 PM",
           "firstActor": "Simon Berry",
-          "type": "PASS",
           "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:33:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:33:03 PM",
           "firstActor": "Ken Maclean",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:33:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:33:04 PM",
           "firstActor": "Jim Robinson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:33:04 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2030,68 +2034,68 @@
         "Jim Robinson",
         "Jaime Boss",
         "Stacey Wowchuk"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:33:58 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:33:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:01 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:34:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:04 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:34:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:12 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:34:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:17 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:34:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:25 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:34:25 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:27 PM",
           "firstActor": "Nick Theriault",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:34:27 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:28 PM",
           "firstActor": "Nick Theriault",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:34:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:34:29 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:34:29 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2101,69 +2105,69 @@
         "Nick Theriault",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Tom Newman",
-        "Darryl Payne",
-        "Melissa Jess",
-        "Justine Price"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:35:17 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Melissa Jess",
-          "timestamp": "Nov 6, 2017 10:35:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:35:23 PM",
           "firstActor": "Melissa Jess",
-          "type": "PASS",
           "secondActor": "Michael Colantonio",
-          "timestamp": "Nov 6, 2017 10:35:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:35:24 PM",
           "firstActor": "Michael Colantonio",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:35:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:35:26 PM",
           "firstActor": "Justine Price",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:35:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:35:30 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:35:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:35:36 PM",
           "firstActor": "Justine Price",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:35:36 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:35:49 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:35:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:35:54 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:35:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:36:01 PM",
           "firstActor": "Simon Berry",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:36:01 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2173,58 +2177,58 @@
         "Jim Robinson",
         "Jaime Boss",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:37:10 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:37:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:15 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:37:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:23 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:37:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:27 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 10:37:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:30 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:37:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:48 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:37:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:49 PM",
           "firstActor": "Cassie Berquist",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:37:49 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2234,56 +2238,56 @@
         "Nick Theriault",
         "Jaime Boss",
         "Stacey Wowchuk"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Simon Berry",
-        "Ken Maclean",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Stacey Wowchuk",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:38:39 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Stacey Wowchuk",
-          "timestamp": "Nov 6, 2017 10:38:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:44 PM",
           "firstActor": "Stacey Wowchuk",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:38:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:46 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:38:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:50 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:38:50 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:52 PM",
           "firstActor": "Justine Price",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:38:52 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:39:01 PM",
           "firstActor": "Richard Gregory",
-          "type": "PASS",
           "secondActor": "Justine Price",
-          "timestamp": "Nov 6, 2017 10:39:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:39:02 PM",
           "firstActor": "Justine Price",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:39:02 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2293,9 +2297,109 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:39:49 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Jaime Boss",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:39:50 PM",
+          "firstActor": "Jaime Boss",
+          "secondActor": "Alessandro Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:39:55 PM",
+          "firstActor": "Alessandro Colantonio",
+          "secondActor": "Andrea Proulx(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:39:58 PM",
+          "firstActor": "Andrea Proulx(S)",
+          "secondActor": "Jim Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:00 PM",
+          "firstActor": "Jim Robinson",
+          "secondActor": "Alessandro Colantonio",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:07 PM",
+          "firstActor": "Alessandro Colantonio",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:21 PM",
+          "firstActor": "Frederic Caron",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:24 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Nicholas Aghajanian",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:31 PM",
+          "firstActor": "Nicholas Aghajanian",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:36 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Wing-Leung Chan",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:42 PM",
+          "firstActor": "Wing-Leung Chan",
+          "secondActor": "Frederic Caron",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:44 PM",
+          "firstActor": "Frederic Caron",
+          "secondActor": "Scott Higgins",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:46 PM",
+          "firstActor": "Scott Higgins",
+          "secondActor": "Kristyn Berquist",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:47 PM",
+          "firstActor": "Kristyn Berquist",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
+      ],
       "offensePlayers": [
         "Alessandro Colantonio",
         "Ken Maclean",
@@ -2303,132 +2407,32 @@
         "Nick Theriault",
         "Jaime Boss",
         "Andrea Proulx(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:39:49 PM"
-        },
-        {
-          "firstActor": "Jaime Boss",
-          "type": "PASS",
-          "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:39:50 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
-          "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:39:55 PM"
-        },
-        {
-          "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
-          "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:39:58 PM"
-        },
-        {
-          "firstActor": "Jim Robinson",
-          "type": "PASS",
-          "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:40:00 PM"
-        },
-        {
-          "firstActor": "Alessandro Colantonio",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:40:07 PM"
-        },
-        {
-          "firstActor": "Frederic Caron",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:40:21 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:40:24 PM"
-        },
-        {
-          "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:40:31 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:40:36 PM"
-        },
-        {
-          "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
-          "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 10:40:42 PM"
-        },
-        {
-          "firstActor": "Frederic Caron",
-          "type": "PASS",
-          "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:40:44 PM"
-        },
-        {
-          "firstActor": "Scott Higgins",
-          "type": "PASS",
-          "secondActor": "Kristyn Berquist",
-          "timestamp": "Nov 6, 2017 10:40:46 PM"
-        },
-        {
-          "firstActor": "Kristyn Berquist",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:40:47 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Simon Berry",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:41:36 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:41:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:41:45 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:41:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:41:53 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:41:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:41:54 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:41:54 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2438,34 +2442,34 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Stacey Wowchuk"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:42:55 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 10:42:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:43:01 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:43:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:43:04 PM",
           "firstActor": "Cassie Berquist",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:43:04 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2475,75 +2479,75 @@
         "Nick Theriault",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Simon Berry",
-        "Ken Maclean",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Jaime Boss",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:43:56 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:43:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:43:59 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:43:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:03 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:44:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:07 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:44:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:13 PM",
           "firstActor": "Simon Berry",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:44:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:23 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:44:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:23 PM",
           "firstActor": "Jaime Boss",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:44:23 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:34 PM",
           "firstActor": "Justine Price",
-          "type": "PASS",
           "secondActor": "Tom Newman",
-          "timestamp": "Nov 6, 2017 10:44:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:37 PM",
           "firstActor": "Tom Newman",
-          "type": "PASS",
           "secondActor": "Melissa Jess",
-          "timestamp": "Nov 6, 2017 10:44:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:44:37 PM",
           "firstActor": "Melissa Jess",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:44:37 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2553,93 +2557,93 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Simon Berry",
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Jaime Boss",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Alessandro Colantonio",
-        "Simon Berry",
-        "Jim Robinson",
-        "Nick Theriault",
-        "Jaime Boss",
-        "Stacey Wowchuk"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:45:31 PM",
           "firstActor": "Jaime Boss",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:45:31 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:45:38 PM",
           "firstActor": "Frederic Caron",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:45:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:45:47 PM",
           "firstActor": "Scott Higgins",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:45:47 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:45:49 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:45:49 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:29 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:46:29 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:46 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:46:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:48 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:46:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:51 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Wing-Leung Chan",
-          "timestamp": "Nov 6, 2017 10:46:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:57 PM",
           "firstActor": "Wing-Leung Chan",
-          "type": "PASS",
           "secondActor": "Frederic Caron",
-          "timestamp": "Nov 6, 2017 10:46:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:59 PM",
           "firstActor": "Frederic Caron",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:46:59 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:47:20 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:47:20 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:47:24 PM",
           "firstActor": "Frederic Caron",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:47:24 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:47:50 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:47:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:47:50 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:47:50 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2649,70 +2653,70 @@
         "Scott Higgins",
         "Cassie Berquist",
         "Kristyn Berquist"
+      ],
+      "offensePlayers": [
+        "Alessandro Colantonio",
+        "Simon Berry",
+        "Jim Robinson",
+        "Nick Theriault",
+        "Jaime Boss",
+        "Stacey Wowchuk"
       ]
     },
     {
-      "offensePlayers": [
-        "Ken Maclean",
-        "Jonathan Pindur",
-        "Geofford Seaborn",
-        "Nick Theriault",
-        "Stacey Wowchuk",
-        "Andrea Proulx(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:48:41 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:48:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:48:49 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
           "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:48:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:48:51 PM",
           "firstActor": "Ken Maclean",
-          "type": "PASS",
           "secondActor": "Stacey Wowchuk",
-          "timestamp": "Nov 6, 2017 10:48:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:48:55 PM",
           "firstActor": "Stacey Wowchuk",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:48:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:06 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:49:06 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:09 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Ken Maclean",
-          "timestamp": "Nov 6, 2017 10:49:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:13 PM",
           "firstActor": "Ken Maclean",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:49:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:18 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
           "secondActor": "Nick Theriault",
-          "timestamp": "Nov 6, 2017 10:49:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:19 PM",
           "firstActor": "Nick Theriault",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:49:19 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2722,105 +2726,105 @@
         "Darryl Payne",
         "Melissa Jess",
         "Justine Price"
+      ],
+      "offensePlayers": [
+        "Ken Maclean",
+        "Jonathan Pindur",
+        "Geofford Seaborn",
+        "Nick Theriault",
+        "Stacey Wowchuk",
+        "Andrea Proulx(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:50:01 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:50:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:06 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:50:06 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:09 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Kristyn Berquist",
-          "timestamp": "Nov 6, 2017 10:50:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:13 PM",
           "firstActor": "Kristyn Berquist",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:50:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:14 PM",
           "firstActor": "Cassie Berquist",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:50:14 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:18 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:50:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:22 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:50:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:24 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:50:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:29 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:50:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:36 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:50:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:41 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:50:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:44 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:50:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:49 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:50:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:56 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:50:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:57 PM",
           "firstActor": "Simon Berry",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:50:57 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2830,51 +2834,51 @@
         "Jim Robinson",
         "Jaime Boss",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     },
     {
-      "offensePlayers": [
-        "Michael Colantonio",
-        "Richard Gregory",
-        "Tom Newman",
-        "Darryl Payne",
-        "Melissa Jess",
-        "Justine Price"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:52:02 PM",
           "firstActor": "Richard Gregory",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:52:02 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:09 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Jaime Boss",
-          "timestamp": "Nov 6, 2017 10:52:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:11 PM",
           "firstActor": "Jaime Boss",
-          "type": "PASS",
           "secondActor": "Jonathan Pindur",
-          "timestamp": "Nov 6, 2017 10:52:11 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:17 PM",
           "firstActor": "Jonathan Pindur",
-          "type": "PASS",
           "secondActor": "Simon Berry",
-          "timestamp": "Nov 6, 2017 10:52:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:19 PM",
           "firstActor": "Simon Berry",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:52:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:20 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:52:20 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2884,110 +2888,110 @@
         "Nick Theriault",
         "Jaime Boss",
         "Stacey Wowchuk"
+      ],
+      "offensePlayers": [
+        "Michael Colantonio",
+        "Richard Gregory",
+        "Tom Newman",
+        "Darryl Payne",
+        "Melissa Jess",
+        "Justine Price"
       ]
     },
     {
-      "offensePlayers": [
-        "Nicholas Aghajanian",
-        "Frederic Caron",
-        "Wing-Leung Chan",
-        "Scott Higgins",
-        "Cassie Berquist",
-        "Kristyn Berquist"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:53:18 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:53:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:21 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:53:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:26 PM",
           "firstActor": "Scott Higgins",
-          "type": "PASS",
           "secondActor": "Cassie Berquist",
-          "timestamp": "Nov 6, 2017 10:53:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:29 PM",
           "firstActor": "Cassie Berquist",
-          "type": "PASS",
           "secondActor": "Nicholas Aghajanian",
-          "timestamp": "Nov 6, 2017 10:53:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:33 PM",
           "firstActor": "Nicholas Aghajanian",
-          "type": "PASS",
           "secondActor": "Scott Higgins",
-          "timestamp": "Nov 6, 2017 10:53:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:37 PM",
           "firstActor": "Scott Higgins",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:53:37 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:38 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:53:38 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:57 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:53:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:03 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:54:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:07 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "PASS",
           "secondActor": "Jim Robinson",
-          "timestamp": "Nov 6, 2017 10:54:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:08 PM",
           "firstActor": "Jim Robinson",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:54:08 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:10 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Geofford Seaborn",
-          "timestamp": "Nov 6, 2017 10:54:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:14 PM",
           "firstActor": "Geofford Seaborn",
-          "type": "PASS",
           "secondActor": "Stacey Wowchuk",
-          "timestamp": "Nov 6, 2017 10:54:14 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:17 PM",
           "firstActor": "Stacey Wowchuk",
-          "type": "PASS",
           "secondActor": "Alessandro Colantonio",
-          "timestamp": "Nov 6, 2017 10:54:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:22 PM",
           "firstActor": "Alessandro Colantonio",
-          "type": "PASS",
           "secondActor": "Andrea Proulx(S)",
-          "timestamp": "Nov 6, 2017 10:54:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:23 PM",
           "firstActor": "Andrea Proulx(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:54:23 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2997,36 +3001,30 @@
         "Geofford Seaborn",
         "Stacey Wowchuk",
         "Andrea Proulx(S)"
+      ],
+      "offensePlayers": [
+        "Nicholas Aghajanian",
+        "Frederic Caron",
+        "Wing-Leung Chan",
+        "Scott Higgins",
+        "Cassie Berquist",
+        "Kristyn Berquist"
       ]
     }
   ],
-  "league": "ocua_17-18",
-  "teams": {
-    "home_team": [
-      "Cassie Berquist",
-      "Kristyn Berquist",
-      "Melissa Jess",
-      "Justine Price",
-      "Nicholas Aghajanian",
-      "Frederic Caron",
-      "Wing-Leung Chan",
-      "Michael Colantonio",
-      "Richard Gregory",
-      "Scott Higgins",
-      "Tom Newman",
-      "Darryl Payne"
-    ],
-    "away_team": [
-      "Jaime Boss",
-      "Stacey Wowchuk",
-      "Andrea Proulx(S)",
-      "Alessandro Colantonio",
-      "Simon Berry",
-      "Ken Maclean",
-      "Jonathan Pindur",
-      "Jim Robinson",
-      "Geofford Seaborn",
-      "Nick Theriault"
-    ]
-  }
+  "week": 1,
+  "homeRoster": [
+    "Cassie Berquist",
+    "Kristyn Berquist",
+    "Melissa Jess",
+    "Justine Price",
+    "Nicholas Aghajanian",
+    "Frederic Caron",
+    "Wing-Leung Chan",
+    "Michael Colantonio",
+    "Richard Gregory",
+    "Scott Higgins",
+    "Tom Newman",
+    "Darryl Payne"
+  ]
 }

--- a/data/ocua_17-18/week1_game4.json
+++ b/data/ocua_17-18/week1_game4.json
@@ -1,47 +1,51 @@
 {
-  "score": {
-    "home_team": 20,
-    "away_team": 16
-  },
-  "week": 1,
+  "awayRoster": [
+    "Neena Sidhu",
+    "Heather Wallace",
+    "Kate Achtell(S)",
+    "Mehmet Karman",
+    "Craig Anderson",
+    "Shubho Bo Biswas",
+    "Giulian De La Merced",
+    "Hadrian Mertins-Kirkwood",
+    "Will Reid",
+    "Stephen Close(S)"
+  ],
+  "awayTeam": "Menace",
+  "homeTeam": "Save Kindha - the Katy Parity Revival",
+  "awayScore": 16,
+  "league": "ocua_17-18",
+  "homeScore": 20,
   "points": [
     {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Hope Celani"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:08:18 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PULL",
-          "timestamp": "Nov 6, 2017 10:08:18 PM"
+          "type": "PULL"
         },
         {
+          "timestamp": "Nov 6, 2017 10:08:38 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:08:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:08:42 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:08:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:08:48 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:08:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:08:49 PM",
           "firstActor": "Hope Celani",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:08:49 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -51,114 +55,114 @@
         "Stephen Close(S)",
         "Neena Sidhu",
         "Heather Wallace"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Will Reid",
-        "Neena Sidhu",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:09:35 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:09:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:09:39 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:09:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:09:44 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:09:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:09:49 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:09:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:09:52 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:09:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:09:58 PM",
           "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:09:58 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:01 PM",
           "firstActor": "Hope Celani",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:10:01 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:15 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:10:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:19 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:10:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:20 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:10:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:22 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:10:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:28 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:10:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:32 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:10:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:35 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:10:35 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:38 PM",
           "firstActor": "Craig Anderson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:10:38 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:47 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:10:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:10:48 PM",
           "firstActor": "Mehmet Karman",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:10:48 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -168,64 +172,64 @@
         "Andre Scott(S)",
         "Hope Celani",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:11:33 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:11:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:39 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:11:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:43 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Trevor Stocki",
-          "timestamp": "Nov 6, 2017 10:11:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:48 PM",
           "firstActor": "Trevor Stocki",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:11:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:51 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:11:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:11:54 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 10:11:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:00 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:12:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:01 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:12:01 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -235,166 +239,166 @@
         "Stephen Close(S)",
         "Heather Wallace",
         "Kate Achtell(S)"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Hadrian Mertins-Kirkwood",
-        "Will Reid",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:12:45 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:12:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:50 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:12:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:12:56 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:12:56 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:07 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:13:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:12 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:13:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:15 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:13:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:23 PM",
           "firstActor": "Hope Celani",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:13:23 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:25 PM",
           "firstActor": "Mehmet Karman",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:13:25 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:27 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:13:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:30 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:13:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:34 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:13:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:36 PM",
           "firstActor": "Will Reid",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:13:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:41 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:13:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:43 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:13:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:48 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:13:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:13:52 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:13:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:01 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:14:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:05 PM",
           "firstActor": "Will Reid",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:14:05 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:32 PM",
           "firstActor": "Jessie Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:14:32 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:34 PM",
           "firstActor": "Mehmet Karman",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:14:34 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:48 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:14:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:51 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:14:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:56 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:14:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:14:59 PM",
           "firstActor": "Neena Sidhu",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:14:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:15:04 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:15:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:15:05 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:15:05 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -404,171 +408,171 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Hope Celani"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Heather Wallace"
       ]
     },
     {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Hope Celani",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:15:55 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "Trevor Stocki",
-          "timestamp": "Nov 6, 2017 10:15:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:15:56 PM",
           "firstActor": "Trevor Stocki",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:15:56 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:10 PM",
           "firstActor": "Giulian De La Merced",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:16:10 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:11 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:16:11 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:19 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:16:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:22 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:16:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:27 PM",
           "firstActor": "Hope Celani",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:16:27 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:28 PM",
           "firstActor": "Kate Achtell(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:16:28 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:30 PM",
           "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:16:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:34 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:16:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:40 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:16:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:41 PM",
           "firstActor": "Neena Sidhu",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:16:41 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:50 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:16:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:51 PM",
           "firstActor": "Hope Celani",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:16:51 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:16:54 PM",
           "firstActor": "Neena Sidhu",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:16:54 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:01 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:17:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:06 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:17:06 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:07 PM",
           "firstActor": "Neena Sidhu",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:17:07 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:11 PM",
           "firstActor": "Trevor Stocki",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:17:11 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:15 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:17:15 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:16 PM",
           "firstActor": "Craig Anderson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:17:16 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:22 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:17:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:40 PM",
           "firstActor": "Craig Anderson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:17:40 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:17:59 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:17:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:18:03 PM",
           "firstActor": "John Haig",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:18:03 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:18:05 PM",
           "firstActor": "Kate Achtell(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:18:05 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:18:09 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:18:09 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:18:10 PM",
           "firstActor": "Neena Sidhu",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:18:10 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -578,378 +582,8 @@
         "Stephen Close(S)",
         "Neena Sidhu",
         "Kate Achtell(S)"
-      ]
-    },
-    {
+      ],
       "offensePlayers": [
-        "Jason Fraser",
-        "Jeff Hunt",
-        "Adam MacDonald",
-        "Andre Scott(S)",
-        "Jessie Robinson",
-        "Josee Guibord(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:18:50 PM"
-        },
-        {
-          "firstActor": "Will Reid",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:18:52 PM"
-        },
-        {
-          "firstActor": "Heather Wallace",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:18:58 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:19:02 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Mehmet Karman",
-        "Giulian De La Merced",
-        "Hadrian Mertins-Kirkwood",
-        "Will Reid",
-        "Heather Wallace",
-        "Kate Achtell(S)"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Hope Celani"
-      ],
-      "events": [
-        {
-          "firstActor": "Greg Probe",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:19:47 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:19:54 PM"
-        },
-        {
-          "firstActor": "Mehmet Karman",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:19:55 PM"
-        },
-        {
-          "firstActor": "Mehmet Karman",
-          "type": "PASS",
-          "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:20:01 PM"
-        },
-        {
-          "firstActor": "Craig Anderson",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:20:05 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:20:06 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Stephen Close(S)",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Jason Fraser",
-        "Jeff Hunt",
-        "Adam MacDonald",
-        "Andre Scott(S)",
-        "Jessie Robinson",
-        "Josee Guibord(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "PASS",
-          "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:20:51 PM"
-        },
-        {
-          "firstActor": "Adam MacDonald",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:21:00 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Giulian De La Merced",
-          "timestamp": "Nov 6, 2017 10:21:19 PM"
-        },
-        {
-          "firstActor": "Giulian De La Merced",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:21:24 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:21:26 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:21:30 PM"
-        },
-        {
-          "firstActor": "Jason Fraser",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:21:32 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:21:37 PM"
-        },
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "PASS",
-          "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:21:42 PM"
-        },
-        {
-          "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
-          "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:21:46 PM"
-        },
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:21:48 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:22:30 PM"
-        },
-        {
-          "firstActor": "Neena Sidhu",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:22:34 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Giulian De La Merced",
-          "timestamp": "Nov 6, 2017 10:22:40 PM"
-        },
-        {
-          "firstActor": "Giulian De La Merced",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:22:41 PM"
-        },
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "PASS",
-          "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:22:49 PM"
-        },
-        {
-          "firstActor": "Josee Guibord(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:22:55 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:22:57 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:22:59 PM"
-        },
-        {
-          "firstActor": "Neena Sidhu",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:23:17 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:23:22 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:23:27 PM"
-        },
-        {
-          "firstActor": "Will Reid",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:23:33 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:23:34 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:23:49 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 10:24:08 PM"
-        },
-        {
-          "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
-          "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:24:10 PM"
-        },
-        {
-          "firstActor": "Neena Sidhu",
-          "type": "PASS",
-          "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 10:24:18 PM"
-        },
-        {
-          "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:24:23 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 10:24:29 PM"
-        },
-        {
-          "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
-          "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:24:31 PM"
-        },
-        {
-          "firstActor": "Will Reid",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:24:42 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:24:43 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:24:50 PM"
-        },
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "PASS",
-          "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:24:51 PM"
-        },
-        {
-          "firstActor": "Adam MacDonald",
-          "type": "PASS",
-          "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:24:53 PM"
-        },
-        {
-          "firstActor": "Andre Scott(S)",
-          "type": "PASS",
-          "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:24:56 PM"
-        },
-        {
-          "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
-          "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:24:59 PM"
-        },
-        {
-          "firstActor": "Adam MacDonald",
-          "type": "PASS",
-          "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:25:04 PM"
-        },
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:25:05 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Shubho Bo Biswas",
-        "Giulian De La Merced",
-        "Hadrian Mertins-Kirkwood",
-        "Will Reid",
-        "Neena Sidhu",
-        "Kate Achtell(S)"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Hadrian Mertins-Kirkwood",
-        "Stephen Close(S)",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ],
-      "events": [
-        {
-          "firstActor": "Heather Wallace",
-          "type": "PASS",
-          "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:25:53 PM"
-        },
-        {
-          "firstActor": "Mehmet Karman",
-          "type": "PASS",
-          "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:25:59 PM"
-        },
-        {
-          "firstActor": "Stephen Close(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:26:00 PM"
-        }
-      ],
-      "defensePlayers": [
         "John Haig",
         "Nick Klimowicz",
         "Greg Probe",
@@ -959,82 +593,452 @@
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:18:50 PM",
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:18:52 PM",
+          "firstActor": "Will Reid",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:18:58 PM",
+          "firstActor": "Heather Wallace",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:19:02 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
       "offensePlayers": [
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
         "Andre Scott(S)",
         "Jessie Robinson",
-        "Hope Celani"
-      ],
+        "Josee Guibord(S)"
+      ]
+    },
+    {
       "events": [
         {
-          "firstActor": "Jessie Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:26:54 PM"
-        },
-        {
-          "firstActor": "Mehmet Karman",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:26:55 PM"
-        },
-        {
-          "firstActor": "Mehmet Karman",
-          "type": "PASS",
-          "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:27:07 PM"
-        },
-        {
-          "firstActor": "Will Reid",
-          "type": "PASS",
-          "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:27:10 PM"
-        },
-        {
-          "firstActor": "Heather Wallace",
-          "type": "PASS",
-          "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:27:14 PM"
-        },
-        {
-          "firstActor": "Stephen Close(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:27:17 PM"
-        },
-        {
+          "timestamp": "Nov 6, 2017 10:19:47 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:27:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:19:54 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:19:55 PM",
+          "firstActor": "Mehmet Karman",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:20:01 PM",
+          "firstActor": "Mehmet Karman",
+          "secondActor": "Craig Anderson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:20:05 PM",
+          "firstActor": "Craig Anderson",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:20:06 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:20:51 PM",
+          "firstActor": "Jeff Hunt",
+          "secondActor": "Adam MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:00 PM",
+          "firstActor": "Adam MacDonald",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:19 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Giulian De La Merced",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:24 PM",
+          "firstActor": "Giulian De La Merced",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:26 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:30 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:32 PM",
+          "firstActor": "Jason Fraser",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:37 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "Jeff Hunt",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:42 PM",
+          "firstActor": "Jeff Hunt",
+          "secondActor": "Josee Guibord(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:46 PM",
+          "firstActor": "Josee Guibord(S)",
+          "secondActor": "Jeff Hunt",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:21:48 PM",
+          "firstActor": "Jeff Hunt",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:30 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Neena Sidhu",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:34 PM",
+          "firstActor": "Neena Sidhu",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:40 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Giulian De La Merced",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:41 PM",
+          "firstActor": "Giulian De La Merced",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:49 PM",
+          "firstActor": "Jeff Hunt",
+          "secondActor": "Josee Guibord(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:55 PM",
+          "firstActor": "Josee Guibord(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:57 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:22:59 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Neena Sidhu",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:23:17 PM",
+          "firstActor": "Neena Sidhu",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:23:22 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:23:27 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Will Reid",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:23:33 PM",
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:23:34 PM",
+          "firstActor": "Jessie Robinson",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:23:49 PM",
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:08 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Kate Achtell(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:10 PM",
+          "firstActor": "Kate Achtell(S)",
+          "secondActor": "Neena Sidhu",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:18 PM",
+          "firstActor": "Neena Sidhu",
+          "secondActor": "Kate Achtell(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:23 PM",
+          "firstActor": "Kate Achtell(S)",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:29 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Kate Achtell(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:31 PM",
+          "firstActor": "Kate Achtell(S)",
+          "secondActor": "Will Reid",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:42 PM",
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:43 PM",
+          "firstActor": "Jessie Robinson",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:50 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "Jeff Hunt",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:51 PM",
+          "firstActor": "Jeff Hunt",
+          "secondActor": "Adam MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:53 PM",
+          "firstActor": "Adam MacDonald",
+          "secondActor": "Andre Scott(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:56 PM",
+          "firstActor": "Andre Scott(S)",
+          "secondActor": "Josee Guibord(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:24:59 PM",
+          "firstActor": "Josee Guibord(S)",
+          "secondActor": "Adam MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:25:04 PM",
+          "firstActor": "Adam MacDonald",
+          "secondActor": "Jeff Hunt",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:25:05 PM",
+          "firstActor": "Jeff Hunt",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ],
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:25:53 PM",
+          "firstActor": "Heather Wallace",
+          "secondActor": "Mehmet Karman",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:25:59 PM",
+          "firstActor": "Mehmet Karman",
+          "secondActor": "Stephen Close(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:26:00 PM",
+          "firstActor": "Stephen Close(S)",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:26:54 PM",
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:26:55 PM",
+          "firstActor": "Mehmet Karman",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:27:07 PM",
+          "firstActor": "Mehmet Karman",
+          "secondActor": "Will Reid",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:27:10 PM",
+          "firstActor": "Will Reid",
+          "secondActor": "Heather Wallace",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:27:14 PM",
+          "firstActor": "Heather Wallace",
+          "secondActor": "Stephen Close(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:27:17 PM",
+          "firstActor": "Stephen Close(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:27:48 PM",
+          "firstActor": "Greg Probe",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:27:48 PM",
+          "firstActor": "Jessie Robinson",
           "secondActor": "Trevor Stocki",
-          "timestamp": "Nov 6, 2017 10:27:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:27:49 PM",
           "firstActor": "Trevor Stocki",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:27:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:27:50 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:27:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:27:51 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:27:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:27:53 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:27:53 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1044,415 +1048,8 @@
         "Stephen Close(S)",
         "Heather Wallace",
         "Kate Achtell(S)"
-      ]
-    },
-    {
+      ],
       "offensePlayers": [
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Hadrian Mertins-Kirkwood",
-        "Will Reid",
-        "Neena Sidhu",
-        "Kate Achtell(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Craig Anderson",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:28:28 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:28:33 PM"
-        },
-        {
-          "firstActor": "Craig Anderson",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:28:35 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 10:28:39 PM"
-        },
-        {
-          "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:28:44 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:29:00 PM"
-        },
-        {
-          "firstActor": "Neena Sidhu",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:29:02 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 10:29:06 PM"
-        },
-        {
-          "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:29:10 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:29:15 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:29:18 PM"
-        },
-        {
-          "firstActor": "Neena Sidhu",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:29:25 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:29:27 PM"
-        },
-        {
-          "firstActor": "Will Reid",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:29:42 PM"
-        },
-        {
-          "firstActor": "Andre Scott(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:29:45 PM"
-        },
-        {
-          "firstActor": "Adam MacDonald",
-          "type": "PASS",
-          "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:29:53 PM"
-        },
-        {
-          "firstActor": "Jason Fraser",
-          "type": "PASS",
-          "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:29:55 PM"
-        },
-        {
-          "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
-          "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:30:00 PM"
-        },
-        {
-          "firstActor": "Adam MacDonald",
-          "type": "PASS",
-          "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:30:02 PM"
-        },
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "PASS",
-          "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:30:04 PM"
-        },
-        {
-          "firstActor": "Hope Celani",
-          "type": "PASS",
-          "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:30:07 PM"
-        },
-        {
-          "firstActor": "Josee Guibord(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:30:14 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:30:36 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:30:42 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:30:45 PM"
-        },
-        {
-          "firstActor": "Neena Sidhu",
-          "type": "PASS",
-          "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:30:47 PM"
-        },
-        {
-          "firstActor": "Will Reid",
-          "type": "PASS",
-          "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:30:51 PM"
-        },
-        {
-          "firstActor": "Neena Sidhu",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:30:53 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:31:03 PM"
-        },
-        {
-          "firstActor": "Craig Anderson",
-          "type": "PASS",
-          "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:31:14 PM"
-        },
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:31:17 PM"
-        },
-        {
-          "firstActor": "Craig Anderson",
-          "type": "PASS",
-          "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:31:21 PM"
-        },
-        {
-          "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:31:22 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Jason Fraser",
-        "Jeff Hunt",
-        "Adam MacDonald",
-        "Andre Scott(S)",
-        "Hope Celani",
-        "Josee Guibord(S)"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Josee Guibord(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Nick Klimowicz",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:32:05 PM"
-        },
-        {
-          "firstActor": "John Haig",
-          "type": "PASS",
-          "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 10:32:09 PM"
-        },
-        {
-          "firstActor": "Greg Probe",
-          "type": "PASS",
-          "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:32:11 PM"
-        },
-        {
-          "firstActor": "Nick Klimowicz",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:32:14 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:32:20 PM"
-        },
-        {
-          "firstActor": "Nick Klimowicz",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:32:22 PM"
-        },
-        {
-          "firstActor": "John Haig",
-          "type": "PASS",
-          "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:32:24 PM"
-        },
-        {
-          "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:32:33 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:32:38 PM"
-        },
-        {
-          "firstActor": "John Haig",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:32:40 PM"
-        }
-      ],
-      "defensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Giulian De La Merced",
-        "Stephen Close(S)",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ]
-    },
-    {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Shubho Bo Biswas",
-        "Hadrian Mertins-Kirkwood",
-        "Will Reid",
-        "Heather Wallace",
-        "Kate Achtell(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:33:22 PM"
-        },
-        {
-          "firstActor": "Jason Fraser",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:33:24 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:33:43 PM"
-        },
-        {
-          "firstActor": "Andre Scott(S)",
-          "type": "PASS",
-          "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:33:44 PM"
-        },
-        {
-          "firstActor": "Jason Fraser",
-          "type": "PASS",
-          "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:33:51 PM"
-        },
-        {
-          "firstActor": "Andre Scott(S)",
-          "type": "PASS",
-          "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:33:54 PM"
-        },
-        {
-          "firstActor": "Adam MacDonald",
-          "type": "PASS",
-          "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:34:08 PM"
-        },
-        {
-          "firstActor": "Andre Scott(S)",
-          "type": "PASS",
-          "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:34:10 PM"
-        },
-        {
-          "firstActor": "Jason Fraser",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:34:12 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:34:24 PM"
-        },
-        {
-          "firstActor": "Adam MacDonald",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:34:25 PM"
-        },
-        {
-          "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:34:43 PM"
-        },
-        {
-          "firstActor": "Andre Scott(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:34:45 PM"
-        },
-        {
-          "firstActor": "Andre Scott(S)",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:34:50 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:34:55 PM"
-        },
-        {
-          "firstActor": "Jeff Hunt",
-          "type": "PASS",
-          "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:34:57 PM"
-        },
-        {
-          "firstActor": "Jason Fraser",
-          "type": "PASS",
-          "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:35:03 PM"
-        },
-        {
-          "firstActor": "Hope Celani",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:35:04 PM"
-        }
-      ],
-      "defensePlayers": [
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
@@ -1462,54 +1059,461 @@
       ]
     },
     {
-      "offensePlayers": [
-        "Craig Anderson",
-        "Giulian De La Merced",
-        "Hadrian Mertins-Kirkwood",
-        "Stephen Close(S)",
-        "Neena Sidhu",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:28:28 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
-          "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:35:52 PM"
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
         },
         {
-          "firstActor": "Stephen Close(S)",
-          "type": "PASS",
-          "secondActor": "Giulian De La Merced",
-          "timestamp": "Nov 6, 2017 10:35:58 PM"
+          "timestamp": "Nov 6, 2017 10:28:33 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Craig Anderson",
+          "type": "PASS"
         },
         {
-          "firstActor": "Giulian De La Merced",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:36:02 PM"
+          "timestamp": "Nov 6, 2017 10:28:35 PM",
+          "firstActor": "Craig Anderson",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
         },
         {
-          "firstActor": "Greg Probe",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:36:15 PM"
+          "timestamp": "Nov 6, 2017 10:28:39 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Kate Achtell(S)",
+          "type": "PASS"
         },
         {
-          "firstActor": "John Haig",
-          "type": "PASS",
-          "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:36:17 PM"
+          "timestamp": "Nov 6, 2017 10:28:44 PM",
+          "firstActor": "Kate Achtell(S)",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
         },
         {
-          "firstActor": "Nick Klimowicz",
-          "type": "PASS",
+          "timestamp": "Nov 6, 2017 10:29:00 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Neena Sidhu",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:02 PM",
+          "firstActor": "Neena Sidhu",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:06 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Kate Achtell(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:10 PM",
+          "firstActor": "Kate Achtell(S)",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:15 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:18 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Neena Sidhu",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:25 PM",
+          "firstActor": "Neena Sidhu",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:27 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Will Reid",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:42 PM",
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:45 PM",
+          "firstActor": "Andre Scott(S)",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:53 PM",
+          "firstActor": "Adam MacDonald",
+          "secondActor": "Jason Fraser",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:29:55 PM",
+          "firstActor": "Jason Fraser",
+          "secondActor": "Josee Guibord(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:00 PM",
+          "firstActor": "Josee Guibord(S)",
+          "secondActor": "Adam MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:02 PM",
+          "firstActor": "Adam MacDonald",
+          "secondActor": "Jeff Hunt",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:04 PM",
+          "firstActor": "Jeff Hunt",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:36:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:30:07 PM",
           "firstActor": "Hope Celani",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:36:24 PM"
+          "secondActor": "Josee Guibord(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:14 PM",
+          "firstActor": "Josee Guibord(S)",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:36 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:42 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:45 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Neena Sidhu",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:47 PM",
+          "firstActor": "Neena Sidhu",
+          "secondActor": "Will Reid",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:51 PM",
+          "firstActor": "Will Reid",
+          "secondActor": "Neena Sidhu",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:30:53 PM",
+          "firstActor": "Neena Sidhu",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:31:03 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Craig Anderson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:31:14 PM",
+          "firstActor": "Craig Anderson",
+          "secondActor": "Shubho Bo Biswas",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:31:17 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Craig Anderson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:31:21 PM",
+          "firstActor": "Craig Anderson",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:31:22 PM",
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:32:05 PM",
+          "firstActor": "Nick Klimowicz",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:09 PM",
+          "firstActor": "John Haig",
+          "secondActor": "Greg Probe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:11 PM",
+          "firstActor": "Greg Probe",
+          "secondActor": "Nick Klimowicz",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:14 PM",
+          "firstActor": "Nick Klimowicz",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:20 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "Nick Klimowicz",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:22 PM",
+          "firstActor": "Nick Klimowicz",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:24 PM",
+          "firstActor": "John Haig",
+          "secondActor": "Josee Guibord(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:33 PM",
+          "firstActor": "Josee Guibord(S)",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:38 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:32:40 PM",
+          "firstActor": "John Haig",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Giulian De La Merced",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:33:22 PM",
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:33:24 PM",
+          "firstActor": "Jason Fraser",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:33:43 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "Andre Scott(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:33:44 PM",
+          "firstActor": "Andre Scott(S)",
+          "secondActor": "Jason Fraser",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:33:51 PM",
+          "firstActor": "Jason Fraser",
+          "secondActor": "Andre Scott(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:33:54 PM",
+          "firstActor": "Andre Scott(S)",
+          "secondActor": "Adam MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:08 PM",
+          "firstActor": "Adam MacDonald",
+          "secondActor": "Andre Scott(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:10 PM",
+          "firstActor": "Andre Scott(S)",
+          "secondActor": "Jason Fraser",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:12 PM",
+          "firstActor": "Jason Fraser",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:24 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "Adam MacDonald",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:25 PM",
+          "firstActor": "Adam MacDonald",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:43 PM",
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:45 PM",
+          "firstActor": "Andre Scott(S)",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:50 PM",
+          "firstActor": "Andre Scott(S)",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:55 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "Jeff Hunt",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:34:57 PM",
+          "firstActor": "Jeff Hunt",
+          "secondActor": "Jason Fraser",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:35:03 PM",
+          "firstActor": "Jason Fraser",
+          "secondActor": "Hope Celani",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:35:04 PM",
+          "firstActor": "Hope Celani",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Hope Celani"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:35:52 PM",
+          "firstActor": "Craig Anderson",
+          "secondActor": "Stephen Close(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:35:58 PM",
+          "firstActor": "Stephen Close(S)",
+          "secondActor": "Giulian De La Merced",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:36:02 PM",
+          "firstActor": "Giulian De La Merced",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:36:15 PM",
+          "firstActor": "Greg Probe",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:36:17 PM",
+          "firstActor": "John Haig",
+          "secondActor": "Nick Klimowicz",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:36:23 PM",
+          "firstActor": "Nick Klimowicz",
+          "secondActor": "Hope Celani",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:36:24 PM",
+          "firstActor": "Hope Celani",
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1519,159 +1523,159 @@
         "Trevor Stocki",
         "Hope Celani",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Craig Anderson",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Shubho Bo Biswas",
-        "Will Reid",
-        "Stephen Close(S)",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:37:05 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:37:05 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:10 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:37:10 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:12 PM",
           "firstActor": "Adam MacDonald",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:37:12 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:14 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:37:14 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:18 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:37:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:24 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:37:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:29 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:37:29 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:52 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:37:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:53 PM",
           "firstActor": "Neena Sidhu",
-          "type": "PASS",
           "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:37:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:37:57 PM",
           "firstActor": "Will Reid",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:37:57 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:15 PM",
           "firstActor": "Jessie Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:38:15 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:18 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:38:18 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:21 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:38:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:22 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 10:38:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:25 PM",
           "firstActor": "Neena Sidhu",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:38:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:28 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:38:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:34 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:38:34 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:46 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:38:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:48 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:38:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:52 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:38:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:38:55 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:38:55 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:39:01 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:39:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:39:05 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:39:05 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:39:10 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:39:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:39:12 PM",
           "firstActor": "Adam MacDonald",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:39:12 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1681,9 +1685,136 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Shubho Bo Biswas",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 10:39:54 PM",
+          "firstActor": "Craig Anderson",
+          "secondActor": "Kate Achtell(S)",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:39:56 PM",
+          "firstActor": "Kate Achtell(S)",
+          "secondActor": "Heather Wallace",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:39:59 PM",
+          "firstActor": "Heather Wallace",
+          "secondActor": "Giulian De La Merced",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:03 PM",
+          "firstActor": "Giulian De La Merced",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:05 PM",
+          "firstActor": "Nick Klimowicz",
+          "type": "DEFENSE"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:16 PM",
+          "firstActor": "Nick Klimowicz",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:19 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:24 PM",
+          "firstActor": "John Haig",
+          "secondActor": "Hope Celani",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:25 PM",
+          "firstActor": "Hope Celani",
+          "type": "DROP"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:30 PM",
+          "firstActor": "Heather Wallace",
+          "secondActor": "Craig Anderson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:34 PM",
+          "firstActor": "Craig Anderson",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:40:52 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "Greg Probe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:41:01 PM",
+          "firstActor": "Greg Probe",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:41:06 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:41:09 PM",
+          "firstActor": "John Haig",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:41:13 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:41:16 PM",
+          "firstActor": "John Haig",
+          "secondActor": "Greg Probe",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:41:22 PM",
+          "firstActor": "Greg Probe",
+          "secondActor": "Nick Klimowicz",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 10:41:36 PM",
+          "firstActor": "Nick Klimowicz",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ],
       "offensePlayers": [
         "Mehmet Karman",
         "Craig Anderson",
@@ -1691,191 +1822,64 @@
         "Hadrian Mertins-Kirkwood",
         "Heather Wallace",
         "Kate Achtell(S)"
-      ],
-      "events": [
-        {
-          "firstActor": "Craig Anderson",
-          "type": "PASS",
-          "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 10:39:54 PM"
-        },
-        {
-          "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
-          "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:39:56 PM"
-        },
-        {
-          "firstActor": "Heather Wallace",
-          "type": "PASS",
-          "secondActor": "Giulian De La Merced",
-          "timestamp": "Nov 6, 2017 10:39:59 PM"
-        },
-        {
-          "firstActor": "Giulian De La Merced",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:40:03 PM"
-        },
-        {
-          "firstActor": "Nick Klimowicz",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:40:05 PM"
-        },
-        {
-          "firstActor": "Nick Klimowicz",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:40:16 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:40:19 PM"
-        },
-        {
-          "firstActor": "John Haig",
-          "type": "PASS",
-          "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:40:24 PM"
-        },
-        {
-          "firstActor": "Hope Celani",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:40:25 PM"
-        },
-        {
-          "firstActor": "Heather Wallace",
-          "type": "PASS",
-          "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:40:30 PM"
-        },
-        {
-          "firstActor": "Craig Anderson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:40:34 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 10:40:52 PM"
-        },
-        {
-          "firstActor": "Greg Probe",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:41:01 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:41:06 PM"
-        },
-        {
-          "firstActor": "John Haig",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:41:09 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:41:13 PM"
-        },
-        {
-          "firstActor": "John Haig",
-          "type": "PASS",
-          "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 10:41:16 PM"
-        },
-        {
-          "firstActor": "Greg Probe",
-          "type": "PASS",
-          "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:41:22 PM"
-        },
-        {
-          "firstActor": "Nick Klimowicz",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:41:36 PM"
-        }
-      ],
-      "defensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Hope Celani"
       ]
     },
     {
-      "offensePlayers": [
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Hadrian Mertins-Kirkwood",
-        "Stephen Close(S)",
-        "Heather Wallace",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:45:58 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PULL",
-          "timestamp": "Nov 6, 2017 10:45:58 PM"
+          "type": "PULL"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:08 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:46:08 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:12 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:46:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:16 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:46:16 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:32 PM",
           "firstActor": "Hope Celani",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:46:32 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:34 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:46:34 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:36 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 10:46:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:37 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:46:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:43 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:46:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:46:43 PM",
           "firstActor": "Heather Wallace",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:46:43 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1885,40 +1889,40 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Hope Celani"
+      ],
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Hope Celani",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:47:28 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:47:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:47:31 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:47:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:47:36 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Trevor Stocki",
-          "timestamp": "Nov 6, 2017 10:47:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:47:38 PM",
           "firstActor": "Trevor Stocki",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:47:38 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1928,51 +1932,51 @@
         "Stephen Close(S)",
         "Neena Sidhu",
         "Heather Wallace"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Giulian De La Merced",
-        "Hadrian Mertins-Kirkwood",
-        "Neena Sidhu",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:48:26 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:48:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:48:34 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:48:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:48:38 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:48:38 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:48:40 PM",
           "firstActor": "Craig Anderson",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:48:40 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:01 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:49:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:08 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:49:08 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -1982,61 +1986,61 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Hadrian Mertins-Kirkwood",
-        "Will Reid",
-        "Stephen Close(S)",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:49:40 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:49:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:43 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:49:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:49:48 PM",
           "firstActor": "Will Reid",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:49:48 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:10 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:50:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:14 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:50:14 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:15 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:50:15 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:22 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:50:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:50:25 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:50:25 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2046,246 +2050,246 @@
         "Trevor Stocki",
         "Jessie Robinson",
         "Hope Celani"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
       ]
     },
     {
-      "offensePlayers": [
-        "Jason Fraser",
-        "Jeff Hunt",
-        "Adam MacDonald",
-        "Andre Scott(S)",
-        "Hope Celani",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:51:20 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:51:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:23 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:51:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:29 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:51:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:32 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:51:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:41 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:51:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:43 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:51:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:46 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:51:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:52 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:51:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:51:59 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:51:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:00 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:52:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:06 PM",
           "firstActor": "Adam MacDonald",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:52:06 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:08 PM",
           "firstActor": "Craig Anderson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:52:08 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:19 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:52:19 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:20 PM",
           "firstActor": "Hope Celani",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:52:20 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:23 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:52:23 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:25 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:52:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:29 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:52:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:33 PM",
           "firstActor": "Adam MacDonald",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:52:33 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:52 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 10:52:52 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:52:57 PM",
           "firstActor": "Kate Achtell(S)",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:52:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:02 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:53:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:06 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:53:06 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:07 PM",
           "firstActor": "Jason Fraser",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:53:07 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:13 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:53:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:17 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:53:17 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:24 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:53:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:28 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:53:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:35 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:53:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:39 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:53:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:43 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:53:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:47 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 10:53:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:53:53 PM",
           "firstActor": "Heather Wallace",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:53:53 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:34 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:54:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:37 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:54:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:41 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:54:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:43 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:54:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:54:55 PM",
           "firstActor": "Jeff Hunt",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:54:55 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:55:01 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 10:55:01 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:55:02 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:55:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:55:03 PM",
           "firstActor": "Craig Anderson",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:55:03 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2295,52 +2299,52 @@
         "Giulian De La Merced",
         "Heather Wallace",
         "Kate Achtell(S)"
+      ],
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:55:51 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:55:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:55:56 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 10:55:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:55:59 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:55:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:56:03 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 10:56:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:56:07 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:56:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:56:15 PM",
           "firstActor": "John Haig",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:56:15 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2350,159 +2354,159 @@
         "Stephen Close(S)",
         "Neena Sidhu",
         "Heather Wallace"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Will Reid",
-        "Neena Sidhu",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:56:51 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:56:51 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:56:55 PM",
           "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:56:55 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:56:57 PM",
           "firstActor": "Hope Celani",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:56:57 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:00 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:57:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:06 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:57:06 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:08 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 10:57:08 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:12 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:57:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:18 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 10:57:18 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:32 PM",
           "firstActor": "Jessie Robinson",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:57:32 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:36 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:57:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:37 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 10:57:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:41 PM",
           "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:57:41 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:57:57 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:57:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:02 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 10:58:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:11 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 10:58:11 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:13 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:58:13 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:15 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:58:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:19 PM",
           "firstActor": "Jeff Hunt",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:58:19 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:29 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 10:58:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:31 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 10:58:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:47 PM",
           "firstActor": "Will Reid",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 10:58:47 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:49 PM",
           "firstActor": "Jeff Hunt",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 10:58:49 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:58 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 10:58:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:58:58 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 10:58:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:59:00 PM",
           "firstActor": "Hope Celani",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 10:59:00 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2512,92 +2516,92 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Hope Celani"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Giulian De La Merced",
-        "Hadrian Mertins-Kirkwood",
-        "Stephen Close(S)",
-        "Heather Wallace",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 10:59:44 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 10:59:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:59:45 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 10:59:45 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 10:59:47 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 10:59:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:59:48 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:59:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:59:53 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:59:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:59:56 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 10:59:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 10:59:58 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 10:59:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:00:04 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:00:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:00:05 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "DROP",
-          "timestamp": "Nov 6, 2017 11:00:05 PM"
+          "type": "DROP"
         },
         {
+          "timestamp": "Nov 6, 2017 11:00:17 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 11:00:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:00:20 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 11:00:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:00:24 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Giulian De La Merced",
-          "timestamp": "Nov 6, 2017 11:00:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:00:25 PM",
           "firstActor": "Giulian De La Merced",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:00:25 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2607,63 +2611,63 @@
         "Trevor Stocki",
         "Hope Celani",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Jason Fraser",
-        "Jeff Hunt",
-        "Adam MacDonald",
-        "Andre Scott(S)",
-        "Jessie Robinson",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:01:22 PM",
           "firstActor": "Jeff Hunt",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:01:22 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:01:44 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 11:01:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:01:49 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 11:01:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:01:58 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 11:01:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:01:58 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Neena Sidhu",
-          "timestamp": "Nov 6, 2017 11:01:58 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:02:00 PM",
           "firstActor": "Neena Sidhu",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 11:02:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:02:04 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 11:02:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:02:05 PM",
           "firstActor": "Will Reid",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:02:05 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2673,45 +2677,45 @@
         "Will Reid",
         "Neena Sidhu",
         "Heather Wallace"
+      ],
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Hope Celani"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:02:48 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 11:02:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:02:55 PM",
           "firstActor": "Hope Celani",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:02:55 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:03:03 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 11:03:03 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:03:07 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 11:03:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:03:10 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:03:10 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2721,76 +2725,76 @@
         "Stephen Close(S)",
         "Neena Sidhu",
         "Kate Achtell(S)"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
       ]
     },
     {
-      "offensePlayers": [
-        "Jason Fraser",
-        "Jeff Hunt",
-        "Adam MacDonald",
-        "Andre Scott(S)",
-        "Hope Celani",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:04:02 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 11:04:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:06 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 11:04:06 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:15 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 11:04:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:22 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 11:04:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:26 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:04:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:29 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:04:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:36 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:04:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:39 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 11:04:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:42 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 11:04:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:04:43 PM",
           "firstActor": "Jason Fraser",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:04:43 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2800,128 +2804,128 @@
         "Will Reid",
         "Heather Wallace",
         "Kate Achtell(S)"
+      ],
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Hadrian Mertins-Kirkwood",
-        "Stephen Close(S)",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:05:21 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 11:05:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:05:27 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 11:05:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:05:29 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 11:05:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:05:33 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 11:05:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:05:44 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 11:05:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:05:47 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 11:05:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:05:58 PM",
           "firstActor": "Heather Wallace",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:05:58 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:05:59 PM",
           "firstActor": "John Haig",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 11:05:59 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:06 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 11:06:06 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:10 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 11:06:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:15 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 11:06:15 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:20 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 11:06:20 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:26 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 11:06:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:29 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:06:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:35 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Trevor Stocki",
-          "timestamp": "Nov 6, 2017 11:06:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:37 PM",
           "firstActor": "Trevor Stocki",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:06:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:41 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 11:06:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:45 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 11:06:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:06:45 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:06:45 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2931,40 +2935,40 @@
         "Trevor Stocki",
         "Jessie Robinson",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
       ]
     },
     {
-      "offensePlayers": [
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Giulian De La Merced",
-        "Will Reid",
-        "Heather Wallace",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:07:40 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 11:07:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:07:46 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Giulian De La Merced",
-          "timestamp": "Nov 6, 2017 11:07:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:07:59 PM",
           "firstActor": "Giulian De La Merced",
-          "type": "PASS",
           "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 11:07:59 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:08:00 PM",
           "firstActor": "Kate Achtell(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:08:00 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -2974,115 +2978,115 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Hope Celani"
+      ],
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Will Reid",
+        "Heather Wallace",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Hope Celani",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:08:39 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 11:08:39 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:08:42 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 11:08:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:08:45 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 11:08:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:08:47 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 11:08:47 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:04 PM",
           "firstActor": "Hope Celani",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:09:04 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:16 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 11:09:16 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:22 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 11:09:22 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:28 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Shubho Bo Biswas",
-          "timestamp": "Nov 6, 2017 11:09:28 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:32 PM",
           "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 11:09:32 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:36 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 11:09:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:40 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:09:40 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:41 PM",
           "firstActor": "Hope Celani",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 11:09:41 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:50 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "PASS",
           "secondActor": "Trevor Stocki",
-          "timestamp": "Nov 6, 2017 11:09:50 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:09:53 PM",
           "firstActor": "Trevor Stocki",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 11:09:53 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:10:27 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 11:10:27 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:10:31 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 11:10:31 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:10:32 PM",
           "firstActor": "Greg Probe",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:10:32 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3092,45 +3096,45 @@
         "Stephen Close(S)",
         "Neena Sidhu",
         "Kate Achtell(S)"
+      ],
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Giulian De La Merced",
-        "Will Reid",
-        "Neena Sidhu",
-        "Heather Wallace"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:11:18 PM",
           "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:11:18 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:11:25 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:11:25 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:11:29 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 11:11:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:11:34 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:11:34 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:11:35 PM",
           "firstActor": "Adam MacDonald",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:11:35 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3140,34 +3144,34 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Giulian De La Merced",
+        "Will Reid",
+        "Neena Sidhu",
+        "Heather Wallace"
       ]
     },
     {
-      "offensePlayers": [
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Hadrian Mertins-Kirkwood",
-        "Stephen Close(S)",
-        "Heather Wallace",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:12:17 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Stephen Close(S)",
-          "timestamp": "Nov 6, 2017 11:12:17 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:12:21 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Kate Achtell(S)",
-          "timestamp": "Nov 6, 2017 11:12:21 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:12:22 PM",
           "firstActor": "Kate Achtell(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:12:22 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3177,121 +3181,121 @@
         "Trevor Stocki",
         "Jessie Robinson",
         "Hope Celani"
+      ],
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Jason Fraser",
-        "Jeff Hunt",
-        "Adam MacDonald",
-        "Andre Scott(S)",
-        "Hope Celani",
-        "Josee Guibord(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:13:14 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 11:13:14 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:16 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:13:16 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:24 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 11:13:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:30 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:13:30 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:37 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 11:13:37 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:43 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "PASS",
           "secondActor": "Mehmet Karman",
-          "timestamp": "Nov 6, 2017 11:13:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:48 PM",
           "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:13:48 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:55 PM",
           "firstActor": "Jeff Hunt",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 11:13:55 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 11:13:56 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:13:56 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:14:02 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 11:14:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:14:07 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 11:14:07 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:14:12 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:14:12 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:15:46 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:15:46 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:15:49 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:15:49 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:15:57 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jason Fraser",
-          "timestamp": "Nov 6, 2017 11:15:57 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:16:00 PM",
           "firstActor": "Jason Fraser",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:16:00 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:16:02 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 11:16:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:16:03 PM",
           "firstActor": "Jeff Hunt",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:16:03 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3301,9 +3305,55 @@
         "Will Reid",
         "Neena Sidhu",
         "Kate Achtell(S)"
+      ],
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
       ]
     },
     {
+      "events": [
+        {
+          "timestamp": "Nov 6, 2017 11:16:44 PM",
+          "firstActor": "Shubho Bo Biswas",
+          "secondActor": "Heather Wallace",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 11:16:47 PM",
+          "firstActor": "Heather Wallace",
+          "type": "THROWAWAY"
+        },
+        {
+          "timestamp": "Nov 6, 2017 11:16:52 PM",
+          "firstActor": "Hope Celani",
+          "secondActor": "Jessie Robinson",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 11:16:56 PM",
+          "firstActor": "Jessie Robinson",
+          "secondActor": "John Haig",
+          "type": "PASS"
+        },
+        {
+          "timestamp": "Nov 6, 2017 11:16:57 PM",
+          "firstActor": "John Haig",
+          "type": "POINT"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ],
       "offensePlayers": [
         "Craig Anderson",
         "Shubho Bo Biswas",
@@ -3311,125 +3361,79 @@
         "Stephen Close(S)",
         "Neena Sidhu",
         "Heather Wallace"
-      ],
-      "events": [
-        {
-          "firstActor": "Shubho Bo Biswas",
-          "type": "PASS",
-          "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 11:16:44 PM"
-        },
-        {
-          "firstActor": "Heather Wallace",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:16:47 PM"
-        },
-        {
-          "firstActor": "Hope Celani",
-          "type": "PASS",
-          "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 11:16:52 PM"
-        },
-        {
-          "firstActor": "Jessie Robinson",
-          "type": "PASS",
-          "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 11:16:56 PM"
-        },
-        {
-          "firstActor": "John Haig",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:16:57 PM"
-        }
-      ],
-      "defensePlayers": [
-        "John Haig",
-        "Nick Klimowicz",
-        "Greg Probe",
-        "Trevor Stocki",
-        "Jessie Robinson",
-        "Hope Celani"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Hadrian Mertins-Kirkwood",
-        "Will Reid",
-        "Stephen Close(S)",
-        "Heather Wallace",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:17:41 PM",
           "firstActor": "Stephen Close(S)",
-          "type": "PASS",
           "secondActor": "Heather Wallace",
-          "timestamp": "Nov 6, 2017 11:17:41 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:17:43 PM",
           "firstActor": "Heather Wallace",
-          "type": "PASS",
           "secondActor": "Will Reid",
-          "timestamp": "Nov 6, 2017 11:17:43 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:17:48 PM",
           "firstActor": "Will Reid",
-          "type": "PASS",
           "secondActor": "Hadrian Mertins-Kirkwood",
-          "timestamp": "Nov 6, 2017 11:17:48 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:17:56 PM",
           "firstActor": "Hadrian Mertins-Kirkwood",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:17:56 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:10 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:18:10 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:19 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:18:19 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:26 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jessie Robinson",
-          "timestamp": "Nov 6, 2017 11:18:26 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:29 PM",
           "firstActor": "Jessie Robinson",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:18:29 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:35 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Adam MacDonald",
-          "timestamp": "Nov 6, 2017 11:18:35 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:40 PM",
           "firstActor": "Adam MacDonald",
-          "type": "PASS",
           "secondActor": "Jeff Hunt",
-          "timestamp": "Nov 6, 2017 11:18:40 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:44 PM",
           "firstActor": "Jeff Hunt",
-          "type": "PASS",
           "secondActor": "Andre Scott(S)",
-          "timestamp": "Nov 6, 2017 11:18:44 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:18:45 PM",
           "firstActor": "Andre Scott(S)",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:18:45 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3439,91 +3443,91 @@
         "Andre Scott(S)",
         "Jessie Robinson",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
       ]
     },
     {
-      "offensePlayers": [
-        "Mehmet Karman",
-        "Craig Anderson",
-        "Shubho Bo Biswas",
-        "Giulian De La Merced",
-        "Neena Sidhu",
-        "Kate Achtell(S)"
-      ],
       "events": [
         {
+          "timestamp": "Nov 6, 2017 11:19:26 PM",
           "firstActor": "Mehmet Karman",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:19:26 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:19:30 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 11:19:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:19:33 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 11:19:33 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:19:36 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Josee Guibord(S)",
-          "timestamp": "Nov 6, 2017 11:19:36 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:19:42 PM",
           "firstActor": "Josee Guibord(S)",
-          "type": "PASS",
           "secondActor": "Hope Celani",
-          "timestamp": "Nov 6, 2017 11:19:42 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:19:45 PM",
           "firstActor": "Hope Celani",
-          "type": "PASS",
           "secondActor": "John Haig",
-          "timestamp": "Nov 6, 2017 11:19:45 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:20:02 PM",
           "firstActor": "John Haig",
-          "type": "PASS",
           "secondActor": "Greg Probe",
-          "timestamp": "Nov 6, 2017 11:20:02 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:20:04 PM",
           "firstActor": "Greg Probe",
-          "type": "PASS",
           "secondActor": "Nick Klimowicz",
-          "timestamp": "Nov 6, 2017 11:20:04 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:20:09 PM",
           "firstActor": "Nick Klimowicz",
-          "type": "THROWAWAY",
-          "timestamp": "Nov 6, 2017 11:20:09 PM"
+          "type": "THROWAWAY"
         },
         {
+          "timestamp": "Nov 6, 2017 11:20:11 PM",
           "firstActor": "Craig Anderson",
-          "type": "DEFENSE",
-          "timestamp": "Nov 6, 2017 11:20:11 PM"
+          "type": "DEFENSE"
         },
         {
+          "timestamp": "Nov 6, 2017 11:20:24 PM",
           "firstActor": "Mehmet Karman",
-          "type": "PASS",
           "secondActor": "Craig Anderson",
-          "timestamp": "Nov 6, 2017 11:20:24 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:20:30 PM",
           "firstActor": "Craig Anderson",
-          "type": "PASS",
           "secondActor": "Giulian De La Merced",
-          "timestamp": "Nov 6, 2017 11:20:30 PM"
+          "type": "PASS"
         },
         {
+          "timestamp": "Nov 6, 2017 11:20:31 PM",
           "firstActor": "Giulian De La Merced",
-          "type": "POINT",
-          "timestamp": "Nov 6, 2017 11:20:31 PM"
+          "type": "POINT"
         }
       ],
       "defensePlayers": [
@@ -3533,35 +3537,29 @@
         "Trevor Stocki",
         "Hope Celani",
         "Josee Guibord(S)"
+      ],
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
       ]
     }
   ],
-  "league": "ocua_17-18",
-  "teams": {
-    "home_team": [
-      "Jessie Robinson",
-      "Hope Celani",
-      "Josee Guibord(S)",
-      "Jason Fraser",
-      "John Haig",
-      "Jeff Hunt",
-      "Nick Klimowicz",
-      "Adam MacDonald",
-      "Greg Probe",
-      "Trevor Stocki",
-      "Andre Scott(S)"
-    ],
-    "away_team": [
-      "Neena Sidhu",
-      "Heather Wallace",
-      "Kate Achtell(S)",
-      "Mehmet Karman",
-      "Craig Anderson",
-      "Shubho Bo Biswas",
-      "Giulian De La Merced",
-      "Hadrian Mertins-Kirkwood",
-      "Will Reid",
-      "Stephen Close(S)"
-    ]
-  }
+  "week": 1,
+  "homeRoster": [
+    "Jessie Robinson",
+    "Hope Celani",
+    "Josee Guibord(S)",
+    "Jason Fraser",
+    "John Haig",
+    "Jeff Hunt",
+    "Nick Klimowicz",
+    "Adam MacDonald",
+    "Greg Probe",
+    "Trevor Stocki",
+    "Andre Scott(S)"
+  ]
 }

--- a/data/ocua_17-18/week1_game4.json
+++ b/data/ocua_17-18/week1_game4.json
@@ -1,0 +1,3567 @@
+{
+  "score": {
+    "home_team": 20,
+    "away_team": 16
+  },
+  "week": 1,
+  "points": [
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ],
+      "events": [
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PULL",
+          "timestamp": "Nov 6, 2017 10:08:18 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:08:38 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:08:42 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:08:48 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:08:49 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:09:35 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:09:39 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:09:44 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:09:49 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:09:52 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:09:58 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:10:01 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:10:15 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:10:19 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:10:20 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:10:22 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:10:28 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:10:32 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:10:35 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:10:38 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:10:47 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:10:48 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:11:33 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:11:39 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Trevor Stocki",
+          "timestamp": "Nov 6, 2017 10:11:43 PM"
+        },
+        {
+          "firstActor": "Trevor Stocki",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:11:48 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:11:51 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 10:11:54 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:12:00 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:12:01 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "events": [
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:12:45 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:12:50 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:12:56 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:13:07 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:13:12 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:13:15 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:13:23 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:13:25 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:13:27 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:13:30 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:13:34 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:13:36 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:13:41 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:13:43 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:13:48 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:13:52 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:14:01 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:14:05 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:14:32 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:14:34 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:14:48 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:14:51 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:14:56 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:14:59 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:15:04 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:15:05 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Trevor Stocki",
+          "timestamp": "Nov 6, 2017 10:15:55 PM"
+        },
+        {
+          "firstActor": "Trevor Stocki",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:15:56 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:16:10 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:16:11 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:16:19 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:16:22 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:16:27 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:16:28 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:16:30 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:16:34 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:16:40 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:16:41 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:16:50 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:16:51 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:16:54 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:17:01 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:17:06 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:17:07 PM"
+        },
+        {
+          "firstActor": "Trevor Stocki",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:17:11 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:17:15 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:17:16 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:17:22 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:17:40 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:17:59 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:18:03 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:18:05 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:18:09 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:18:10 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:18:50 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:18:52 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:18:58 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:19:02 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ],
+      "events": [
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:19:47 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:19:54 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:19:55 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:20:01 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:20:05 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:20:06 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:20:51 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:21:00 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Giulian De La Merced",
+          "timestamp": "Nov 6, 2017 10:21:19 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:21:24 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:21:26 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:21:30 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:21:32 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:21:37 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:21:42 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:21:46 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:21:48 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:22:30 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:22:34 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Giulian De La Merced",
+          "timestamp": "Nov 6, 2017 10:22:40 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:22:41 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:22:49 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:22:55 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:22:57 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:22:59 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:23:17 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:23:22 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:23:27 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:23:33 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:23:34 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:23:49 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 10:24:08 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:24:10 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 10:24:18 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:24:23 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 10:24:29 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:24:31 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:24:42 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:24:43 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:24:50 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:24:51 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:24:53 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:24:56 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:24:59 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:25:04 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:25:05 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "events": [
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:25:53 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:25:59 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:26:00 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Hope Celani"
+      ],
+      "events": [
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:26:54 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:26:55 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:27:07 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:27:10 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:27:14 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:27:17 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:27:48 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Trevor Stocki",
+          "timestamp": "Nov 6, 2017 10:27:48 PM"
+        },
+        {
+          "firstActor": "Trevor Stocki",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:27:49 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:27:50 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:27:51 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:27:53 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:28:28 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:28:33 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:28:35 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 10:28:39 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:28:44 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:29:00 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:29:02 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 10:29:06 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:29:10 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:29:15 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:29:18 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:29:25 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:29:27 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:29:42 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:29:45 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:29:53 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:29:55 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:30:00 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:30:02 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:30:04 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:30:07 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:30:14 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:30:36 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:30:42 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:30:45 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:30:47 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:30:51 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:30:53 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:31:03 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:31:14 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:31:17 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:31:21 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:31:22 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:32:05 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 10:32:09 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:32:11 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:32:14 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:32:20 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:32:22 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:32:24 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:32:33 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:32:38 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:32:40 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Giulian De La Merced",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:33:22 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:33:24 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:33:43 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:33:44 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:33:51 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:33:54 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:34:08 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:34:10 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:34:12 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:34:24 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:34:25 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:34:43 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:34:45 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:34:50 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:34:55 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:34:57 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:35:03 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:35:04 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Craig Anderson",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:35:52 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Giulian De La Merced",
+          "timestamp": "Nov 6, 2017 10:35:58 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:36:02 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:36:15 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:36:17 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:36:23 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:36:24 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Shubho Bo Biswas",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "events": [
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:37:05 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:37:10 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:37:12 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:37:14 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:37:18 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:37:24 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:37:29 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:37:52 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:37:53 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:37:57 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:38:15 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:38:18 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:38:21 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 10:38:22 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:38:25 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:38:28 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:38:34 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:38:46 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:38:48 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:38:52 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:38:55 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:39:01 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:39:05 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:39:10 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:39:12 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 10:39:54 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:39:56 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Giulian De La Merced",
+          "timestamp": "Nov 6, 2017 10:39:59 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:40:03 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:40:05 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:40:16 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:40:19 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:40:24 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:40:25 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:40:30 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:40:34 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 10:40:52 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:41:01 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:41:06 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:41:09 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:41:13 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 10:41:16 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:41:22 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:41:36 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PULL",
+          "timestamp": "Nov 6, 2017 10:45:58 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:46:08 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:46:12 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:46:16 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:46:32 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:46:34 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 10:46:36 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:46:37 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:46:43 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:46:43 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:47:28 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:47:31 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Trevor Stocki",
+          "timestamp": "Nov 6, 2017 10:47:36 PM"
+        },
+        {
+          "firstActor": "Trevor Stocki",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:47:38 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:48:26 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:48:34 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:48:38 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:48:40 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:49:01 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:49:08 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "events": [
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:49:40 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:49:43 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:49:48 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:50:10 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:50:14 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:50:15 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:50:22 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:50:25 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:51:20 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:51:23 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:51:29 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:51:32 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:51:41 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:51:43 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:51:46 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:51:52 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:51:59 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:52:00 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:52:06 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:52:08 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:52:19 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:52:20 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:52:23 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:52:25 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:52:29 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:52:33 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 10:52:52 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:52:57 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:53:02 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:53:06 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:53:07 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:53:13 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:53:17 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:53:24 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:53:28 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:53:35 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:53:39 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:53:43 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 10:53:47 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:53:53 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:54:34 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:54:37 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:54:41 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:54:43 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:54:55 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 10:55:01 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:55:02 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:55:03 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:55:51 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 10:55:56 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:55:59 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 10:56:03 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:56:07 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:56:15 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:56:51 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:56:55 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:56:57 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:57:00 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:57:06 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 10:57:08 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:57:12 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 10:57:18 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:57:32 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:57:36 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 10:57:37 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:57:41 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:57:57 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 10:58:02 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 10:58:11 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:58:13 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:58:15 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:58:19 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 10:58:29 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 10:58:31 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 10:58:47 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 10:58:49 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 10:58:58 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 10:58:58 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 10:59:00 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 10:59:44 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 10:59:45 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 10:59:47 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:59:48 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:59:53 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 10:59:56 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 10:59:58 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:00:04 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "DROP",
+          "timestamp": "Nov 6, 2017 11:00:05 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 11:00:17 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 11:00:20 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Giulian De La Merced",
+          "timestamp": "Nov 6, 2017 11:00:24 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:00:25 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:01:22 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 11:01:44 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 11:01:49 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 11:01:58 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Neena Sidhu",
+          "timestamp": "Nov 6, 2017 11:01:58 PM"
+        },
+        {
+          "firstActor": "Neena Sidhu",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 11:02:00 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 11:02:04 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:02:05 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ],
+      "events": [
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 11:02:48 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:02:55 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 11:03:03 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 11:03:07 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:03:10 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 11:04:02 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 11:04:06 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 11:04:15 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 11:04:22 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:04:26 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:04:29 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:04:36 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 11:04:39 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 11:04:42 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:04:43 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Will Reid",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "events": [
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 11:05:21 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 11:05:27 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 11:05:29 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 11:05:33 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 11:05:44 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 11:05:47 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:05:58 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 11:05:59 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 11:06:06 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 11:06:10 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 11:06:15 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 11:06:20 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 11:06:26 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:06:29 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Trevor Stocki",
+          "timestamp": "Nov 6, 2017 11:06:35 PM"
+        },
+        {
+          "firstActor": "Trevor Stocki",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:06:37 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 11:06:41 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 11:06:45 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:06:45 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Will Reid",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 11:07:40 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Giulian De La Merced",
+          "timestamp": "Nov 6, 2017 11:07:46 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 11:07:59 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:08:00 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 11:08:39 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 11:08:42 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 11:08:45 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 11:08:47 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:09:04 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 11:09:16 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 11:09:22 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Shubho Bo Biswas",
+          "timestamp": "Nov 6, 2017 11:09:28 PM"
+        },
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 11:09:32 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 11:09:36 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:09:40 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 11:09:41 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "PASS",
+          "secondActor": "Trevor Stocki",
+          "timestamp": "Nov 6, 2017 11:09:50 PM"
+        },
+        {
+          "firstActor": "Trevor Stocki",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 11:09:53 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 11:10:27 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 11:10:31 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:10:32 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Giulian De La Merced",
+        "Will Reid",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "events": [
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:11:18 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:11:25 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 11:11:29 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:11:34 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:11:35 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Hadrian Mertins-Kirkwood",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Stephen Close(S)",
+          "timestamp": "Nov 6, 2017 11:12:17 PM"
+        },
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Kate Achtell(S)",
+          "timestamp": "Nov 6, 2017 11:12:21 PM"
+        },
+        {
+          "firstActor": "Kate Achtell(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:12:22 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 11:13:14 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:13:16 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 11:13:24 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:13:30 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 11:13:37 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "PASS",
+          "secondActor": "Mehmet Karman",
+          "timestamp": "Nov 6, 2017 11:13:43 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:13:48 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 11:13:55 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:13:56 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 11:14:02 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 11:14:07 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:14:12 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:15:46 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:15:49 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jason Fraser",
+          "timestamp": "Nov 6, 2017 11:15:57 PM"
+        },
+        {
+          "firstActor": "Jason Fraser",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:16:00 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 11:16:02 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:16:03 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Mehmet Karman",
+        "Giulian De La Merced",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Stephen Close(S)",
+        "Neena Sidhu",
+        "Heather Wallace"
+      ],
+      "events": [
+        {
+          "firstActor": "Shubho Bo Biswas",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 11:16:44 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:16:47 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 11:16:52 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 11:16:56 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:16:57 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Jessie Robinson",
+        "Hope Celani"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Hadrian Mertins-Kirkwood",
+        "Will Reid",
+        "Stephen Close(S)",
+        "Heather Wallace",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Stephen Close(S)",
+          "type": "PASS",
+          "secondActor": "Heather Wallace",
+          "timestamp": "Nov 6, 2017 11:17:41 PM"
+        },
+        {
+          "firstActor": "Heather Wallace",
+          "type": "PASS",
+          "secondActor": "Will Reid",
+          "timestamp": "Nov 6, 2017 11:17:43 PM"
+        },
+        {
+          "firstActor": "Will Reid",
+          "type": "PASS",
+          "secondActor": "Hadrian Mertins-Kirkwood",
+          "timestamp": "Nov 6, 2017 11:17:48 PM"
+        },
+        {
+          "firstActor": "Hadrian Mertins-Kirkwood",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:17:56 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:18:10 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:18:19 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jessie Robinson",
+          "timestamp": "Nov 6, 2017 11:18:26 PM"
+        },
+        {
+          "firstActor": "Jessie Robinson",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:18:29 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Adam MacDonald",
+          "timestamp": "Nov 6, 2017 11:18:35 PM"
+        },
+        {
+          "firstActor": "Adam MacDonald",
+          "type": "PASS",
+          "secondActor": "Jeff Hunt",
+          "timestamp": "Nov 6, 2017 11:18:40 PM"
+        },
+        {
+          "firstActor": "Jeff Hunt",
+          "type": "PASS",
+          "secondActor": "Andre Scott(S)",
+          "timestamp": "Nov 6, 2017 11:18:44 PM"
+        },
+        {
+          "firstActor": "Andre Scott(S)",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:18:45 PM"
+        }
+      ],
+      "defensePlayers": [
+        "Jason Fraser",
+        "Jeff Hunt",
+        "Adam MacDonald",
+        "Andre Scott(S)",
+        "Jessie Robinson",
+        "Josee Guibord(S)"
+      ]
+    },
+    {
+      "offensePlayers": [
+        "Mehmet Karman",
+        "Craig Anderson",
+        "Shubho Bo Biswas",
+        "Giulian De La Merced",
+        "Neena Sidhu",
+        "Kate Achtell(S)"
+      ],
+      "events": [
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:19:26 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 11:19:30 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 11:19:33 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Josee Guibord(S)",
+          "timestamp": "Nov 6, 2017 11:19:36 PM"
+        },
+        {
+          "firstActor": "Josee Guibord(S)",
+          "type": "PASS",
+          "secondActor": "Hope Celani",
+          "timestamp": "Nov 6, 2017 11:19:42 PM"
+        },
+        {
+          "firstActor": "Hope Celani",
+          "type": "PASS",
+          "secondActor": "John Haig",
+          "timestamp": "Nov 6, 2017 11:19:45 PM"
+        },
+        {
+          "firstActor": "John Haig",
+          "type": "PASS",
+          "secondActor": "Greg Probe",
+          "timestamp": "Nov 6, 2017 11:20:02 PM"
+        },
+        {
+          "firstActor": "Greg Probe",
+          "type": "PASS",
+          "secondActor": "Nick Klimowicz",
+          "timestamp": "Nov 6, 2017 11:20:04 PM"
+        },
+        {
+          "firstActor": "Nick Klimowicz",
+          "type": "THROWAWAY",
+          "timestamp": "Nov 6, 2017 11:20:09 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "DEFENSE",
+          "timestamp": "Nov 6, 2017 11:20:11 PM"
+        },
+        {
+          "firstActor": "Mehmet Karman",
+          "type": "PASS",
+          "secondActor": "Craig Anderson",
+          "timestamp": "Nov 6, 2017 11:20:24 PM"
+        },
+        {
+          "firstActor": "Craig Anderson",
+          "type": "PASS",
+          "secondActor": "Giulian De La Merced",
+          "timestamp": "Nov 6, 2017 11:20:30 PM"
+        },
+        {
+          "firstActor": "Giulian De La Merced",
+          "type": "POINT",
+          "timestamp": "Nov 6, 2017 11:20:31 PM"
+        }
+      ],
+      "defensePlayers": [
+        "John Haig",
+        "Nick Klimowicz",
+        "Greg Probe",
+        "Trevor Stocki",
+        "Hope Celani",
+        "Josee Guibord(S)"
+      ]
+    }
+  ],
+  "league": "ocua_17-18",
+  "teams": {
+    "home_team": [
+      "Jessie Robinson",
+      "Hope Celani",
+      "Josee Guibord(S)",
+      "Jason Fraser",
+      "John Haig",
+      "Jeff Hunt",
+      "Nick Klimowicz",
+      "Adam MacDonald",
+      "Greg Probe",
+      "Trevor Stocki",
+      "Andre Scott(S)"
+    ],
+    "away_team": [
+      "Neena Sidhu",
+      "Heather Wallace",
+      "Kate Achtell(S)",
+      "Mehmet Karman",
+      "Craig Anderson",
+      "Shubho Bo Biswas",
+      "Giulian De La Merced",
+      "Hadrian Mertins-Kirkwood",
+      "Will Reid",
+      "Stephen Close(S)"
+    ]
+  }
+}

--- a/server/app.py
+++ b/server/app.py
@@ -27,7 +27,7 @@ def create_app():
         debug = False
         if debug:
             now = datetime.datetime.now()
-            fo = open('data/test/' + str(now) + '.json', 'wb')
+            fo = open('data/test/' + str(now) + '.json', 'w')
             fo.write(json.dumps(request.json))
             fo.close()
 

--- a/server/backup.py
+++ b/server/backup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import urllib.request, json, os
+from collections import defaultdict
+
+
+def backup(src_url, target_dir):
+    games = fetch_games(src_url)
+
+    game_counts = defaultdict(int)
+
+    for game in games:
+        week = str(game["week"])
+        game_counts[week] += 1
+        game_num = str(game_counts[week])
+
+        file_name = "week" + week + "_game" + game_num + ".json"
+        fo = open(os.path.join(target_dir, file_name), "w")
+        fo.write(json.dumps(game))
+        fo.close()
+
+
+def fetch_games(src_url):
+    with urllib.request.urlopen(src_url) as url:
+        return json.loads(url.read().decode())
+
+
+if __name__ == "__main__":
+    src_url = "https://parity-server.herokuapp.com/games"
+    target_dir = "data/ocua_17-18"
+    backup(src_url, target_dir)

--- a/server/seed.py
+++ b/server/seed.py
@@ -3,7 +3,10 @@
 import glob, os
 import requests
 
-os.chdir("data/test/")
+# src = "data/test/"
+src = "data/ocua_17-18/"
+
+os.chdir(src)
 
 for file in glob.glob("*.json"):
     url = 'http://localhost:5000/upload'


### PR DESCRIPTION
Adds a backup script to download the `games` table from the api. This is useful because the games table holds the raw uploads from the tablets and the rest of the database can be built from just this data. I updated the `seed.py` to upload the current backup of this seasons real data so we can develop locally using real data easily.

@wingleungchan @patrickkenzie @keatesc