### PR TITLE
remove the salary padding

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -104,6 +104,7 @@ def create_app():
 
         for game in games:
             week = max(week, game.week)
+
             for player_stats in Stats.query.filter_by(game_id=game.id):
                 player = Player.query.get(player_stats.player_id)
 
@@ -123,19 +124,10 @@ def create_app():
                 else:
                     stats.update({player.name: data})
 
-        # display salary
-        ## multiply salary by week number for ever growing salary
-        ## add base salary
         for player in stats:
-            base_salary = 50000 * float(week)
             pro_rated_salary = stats[player]['salary'] * float(week)
-            stats[player]['salary'] = base_salary + pro_rated_salary
+            stats[player]['salary'] = pro_rated_salary
 
-        # display pay
-        for player in stats:
-            base_pay = 50000
-            pay = stats[player]['pay']
-            stats[player]['pay'] = base_pay + pay
 
         return stats
 


### PR DESCRIPTION
I added some weird things to try and avoid negative pay or salaries. It skews comparisons and after discussing with @keatesc we decided to remove it. Negative `pay` will happen but it will be rare. With the new calculation I think it is less likely someone will have negative salary_per_point overall since it will be averaged over many games.