### PR TITLE
don't count substitutes

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -109,8 +109,11 @@ def create_app():
 
                 if player.name in json.loads(game.home_roster):
                     team = game.home_team
-                else:
+                elif player.name in json.loads(game.away_roster):
                     team = game.away_team
+
+                if "(S)" in player.name:
+                    team = "Substitute"
 
                 data = player_stats.to_dict()
                 data.update({'team': team})


### PR DESCRIPTION
closes #118

Adds back the magic team name `Substitute`. The UI knows about this magic team name and doesn't include it for team analysis. This also changes the team name in the raw stats view.

 @keatesc