### PR TITLE
Absent players

### DIFF
--- a/data/ocua_17-18/week1_game1.json
+++ b/data/ocua_17-18/week1_game1.json
@@ -13,7 +13,7 @@
     "Jamie Wildgen"
   ],
   "awayTeam": "Stack Over Flow",
-  "homeTeam": "Huck and Hope Handler Academy (Hope)",
+  "homeTeam": "Huck and Hope Handler Academy",
   "awayScore": 19,
   "league": "ocua_17-18",
   "homeScore": 17,

--- a/data/ocua_17-18/week1_game4.json
+++ b/data/ocua_17-18/week1_game4.json
@@ -169,7 +169,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Hope Celani",
         "Josee Guibord(S)"
       ],
@@ -405,7 +405,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Hope Celani"
       ],
@@ -628,7 +628,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Josee Guibord(S)"
       ]
@@ -889,12 +889,12 @@
         {
           "timestamp": "Nov 6, 2017 10:24:53 PM",
           "firstActor": "Adam MacDonald",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:24:56 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Josee Guibord(S)",
           "type": "PASS"
         },
@@ -928,7 +928,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Josee Guibord(S)"
       ]
@@ -1053,7 +1053,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Hope Celani"
       ]
@@ -1145,7 +1145,7 @@
         },
         {
           "timestamp": "Nov 6, 2017 10:29:45 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "type": "DEFENSE"
         },
         {
@@ -1259,7 +1259,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Hope Celani",
         "Josee Guibord(S)"
       ],
@@ -1366,36 +1366,36 @@
         {
           "timestamp": "Nov 6, 2017 10:33:43 PM",
           "firstActor": "Jessie Robinson",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:33:44 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Jason Fraser",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:33:51 PM",
           "firstActor": "Jason Fraser",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:33:54 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Adam MacDonald",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:34:08 PM",
           "firstActor": "Adam MacDonald",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:34:10 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Jason Fraser",
           "type": "PASS"
         },
@@ -1423,12 +1423,12 @@
         },
         {
           "timestamp": "Nov 6, 2017 10:34:45 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "type": "DEFENSE"
         },
         {
           "timestamp": "Nov 6, 2017 10:34:50 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Jessie Robinson",
           "type": "PASS"
         },
@@ -1460,7 +1460,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Hope Celani"
       ],
@@ -1566,12 +1566,12 @@
         {
           "timestamp": "Nov 6, 2017 10:37:24 PM",
           "firstActor": "Josee Guibord(S)",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:37:29 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "type": "THROWAWAY"
         },
         {
@@ -1682,7 +1682,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Josee Guibord(S)"
       ],
@@ -1886,7 +1886,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Hope Celani"
       ],
@@ -1983,7 +1983,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Josee Guibord(S)"
       ],
@@ -2083,12 +2083,12 @@
         {
           "timestamp": "Nov 6, 2017 10:51:32 PM",
           "firstActor": "Hope Celani",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:51:41 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Jeff Hunt",
           "type": "PASS"
         },
@@ -2196,12 +2196,12 @@
         {
           "timestamp": "Nov 6, 2017 10:53:13 PM",
           "firstActor": "Adam MacDonald",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:53:17 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "type": "THROWAWAY"
         },
         {
@@ -2304,7 +2304,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Hope Celani",
         "Josee Guibord(S)"
       ]
@@ -2403,12 +2403,12 @@
         {
           "timestamp": "Nov 6, 2017 10:57:12 PM",
           "firstActor": "Jason Fraser",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:57:18 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Jessie Robinson",
           "type": "PASS"
         },
@@ -2449,12 +2449,12 @@
         {
           "timestamp": "Nov 6, 2017 10:58:11 PM",
           "firstActor": "Adam MacDonald",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 10:58:13 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Hope Celani",
           "type": "PASS"
         },
@@ -2513,7 +2513,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Hope Celani"
       ],
@@ -2682,7 +2682,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Josee Guibord(S)"
       ]
@@ -2746,24 +2746,24 @@
         {
           "timestamp": "Nov 6, 2017 11:04:06 PM",
           "firstActor": "Jason Fraser",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 11:04:15 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Jason Fraser",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 11:04:22 PM",
           "firstActor": "Jason Fraser",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 11:04:26 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Adam MacDonald",
           "type": "PASS"
         },
@@ -2809,7 +2809,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Hope Celani",
         "Josee Guibord(S)"
       ]
@@ -2975,7 +2975,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Hope Celani"
       ],
@@ -3141,7 +3141,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Josee Guibord(S)"
       ],
@@ -3208,12 +3208,12 @@
         {
           "timestamp": "Nov 6, 2017 11:13:24 PM",
           "firstActor": "Josee Guibord(S)",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 11:13:30 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "type": "THROWAWAY"
         },
         {
@@ -3253,12 +3253,12 @@
         {
           "timestamp": "Nov 6, 2017 11:14:07 PM",
           "firstActor": "Jason Fraser",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 11:14:12 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "secondActor": "Adam MacDonald",
           "type": "PASS"
         },
@@ -3310,7 +3310,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Hope Celani",
         "Josee Guibord(S)"
       ]
@@ -3427,12 +3427,12 @@
         {
           "timestamp": "Nov 6, 2017 11:18:44 PM",
           "firstActor": "Jeff Hunt",
-          "secondActor": "Andre Scott(S)",
+          "secondActor": "Andre Scott",
           "type": "PASS"
         },
         {
           "timestamp": "Nov 6, 2017 11:18:45 PM",
-          "firstActor": "Andre Scott(S)",
+          "firstActor": "Andre Scott",
           "type": "POINT"
         }
       ],
@@ -3440,7 +3440,7 @@
         "Jason Fraser",
         "Jeff Hunt",
         "Adam MacDonald",
-        "Andre Scott(S)",
+        "Andre Scott",
         "Jessie Robinson",
         "Josee Guibord(S)"
       ],
@@ -3560,6 +3560,6 @@
     "Adam MacDonald",
     "Greg Probe",
     "Trevor Stocki",
-    "Andre Scott(S)"
+    "Andre Scott"
   ]
 }

--- a/server/app.py
+++ b/server/app.py
@@ -141,7 +141,9 @@ def create_app():
             if player.salary > 0:
                 player_stats.update({'salary': player.salary})
             else:
-                avg_salary = 0
+                team_players = Player.query.filter_by(team_id=player.team_id)
+                same_gender_salaries = [p.salary for p in team_players if p.is_male == player.is_male and p.salary > 0]
+                avg_salary = sum(same_gender_salaries) / len(same_gender_salaries)
                 player_stats.update({'salary': avg_salary})
 
             stats[player.name] = player_stats

--- a/server/app.py
+++ b/server/app.py
@@ -69,7 +69,7 @@ def create_app():
             }
             for player in Player.query.filter_by(team_id=team.id):
                 teams[team.name]['players'].append(player.name)
-                if player.is_male():
+                if player.is_male:
                     teams[team.name]['malePlayers'].append(player.name)
                 else:
                     teams[team.name]['femalePlayers'].append(player.name)
@@ -99,11 +99,13 @@ def create_app():
 
 
     def build_stats_response(games):
+        present_players = []
         stats = {}
         week = 0
 
         for game in games:
             week = max(week, game.week)
+            present_players = present_players + game.players
 
             for player_stats in Stats.query.filter_by(game_id=game.id):
                 player = Player.query.get(player_stats.player_id)
@@ -126,6 +128,9 @@ def create_app():
                     stats[player.name].update(summed_stats)
                 else:
                     stats.update({player.name: data})
+
+        players = Player.query.filter(Player.team_id != None)
+        absent_players = [player for player in players if player.name not in present_players]
 
         for player in stats:
             pro_rated_salary = stats[player]['salary'] * float(week)

--- a/server/app.py
+++ b/server/app.py
@@ -129,8 +129,23 @@ def create_app():
                 else:
                     stats.update({player.name: data})
 
+
         players = Player.query.filter(Player.team_id != None)
         absent_players = [player for player in players if player.name not in present_players]
+
+        for player in absent_players:
+            game_id = -1
+            player_stats = Stats(game_id, player.id).to_dict()
+            player_stats.update({'team': player.team.name})
+
+            if player.salary > 0:
+                player_stats.update({'salary': player.salary})
+            else:
+                avg_salary = 0
+                player_stats.update({'salary': avg_salary})
+
+            stats[player.name] = player_stats
+
 
         for player in stats:
             pro_rated_salary = stats[player]['salary'] * float(week)

--- a/server/models.py
+++ b/server/models.py
@@ -19,6 +19,25 @@ class Player(db.Model):
     def is_male(self):
         return self.gender == 'male'
 
+    @property
+    def team(self):
+        return Team.query.get(self.team_id)
+
+    @property
+    def salary(self):
+        pro_rated_number_of_points = 15
+        return self._avg_salary_per_point_based_on_history * pro_rated_number_of_points
+
+    @property
+    def _avg_salary_per_point_based_on_history(self):
+        player_stats = Stats.query.filter_by(player_id=self.id)
+        salaries = [ps.salary_per_point for ps in player_stats]
+
+        if len(salaries) > 0:
+            return sum(salaries) / len(salaries)
+        else:
+            return 0
+
 
 class Game(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -66,21 +85,21 @@ class Stats(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     game_id = db.Column(db.Integer, nullable=False)
     player_id = db.Column(db.Integer, nullable=False)
-    goals = db.Column(db.Integer, default=0)
-    assists = db.Column(db.Integer, default=0)
-    second_assists = db.Column(db.Integer, default=0)
-    d_blocks = db.Column(db.Integer, default=0)
-    completions = db.Column(db.Integer, default=0)
-    throw_aways = db.Column(db.Integer, default=0)
-    threw_drops = db.Column(db.Integer, default=0)
-    catches = db.Column(db.Integer, default=0)
-    drops = db.Column(db.Integer, default=0)
-    pulls = db.Column(db.Integer, default=0)
-    callahan = db.Column(db.Integer, default=0)
-    o_points_for = db.Column(db.Integer, default=0)
-    o_points_against = db.Column(db.Integer, default=0)
-    d_points_for = db.Column(db.Integer, default=0)
-    d_points_against = db.Column(db.Integer, default=0)
+    goals = db.Column(db.Integer)
+    assists = db.Column(db.Integer)
+    second_assists = db.Column(db.Integer)
+    d_blocks = db.Column(db.Integer)
+    completions = db.Column(db.Integer)
+    throw_aways = db.Column(db.Integer)
+    threw_drops = db.Column(db.Integer)
+    catches = db.Column(db.Integer)
+    drops = db.Column(db.Integer)
+    pulls = db.Column(db.Integer)
+    callahan = db.Column(db.Integer)
+    o_points_for = db.Column(db.Integer)
+    o_points_against = db.Column(db.Integer)
+    d_points_for = db.Column(db.Integer)
+    d_points_against = db.Column(db.Integer)
 
     def __init__(self, game_id, player_id):
         self.game_id = game_id
@@ -133,18 +152,7 @@ class Stats(db.Model):
 
     @property
     def salary(self):
-        pro_rated_number_of_points = 15
-        return self._avg_salary_per_point_based_on_history * pro_rated_number_of_points
-
-    @property
-    def _avg_salary_per_point_based_on_history(self):
-        player_stats = Stats.query.filter_by(player_id=self.player_id)
-        salaries = [ps.salary_per_point for ps in player_stats]
-
-        if len(salaries) > 0:
-            return sum(salaries) / len(salaries)
-        else:
-            return 0
+        return Player.query.get(self.player_id).salary
 
     def to_dict(self):
         return {

--- a/server/models.py
+++ b/server/models.py
@@ -152,7 +152,8 @@ class Stats(db.Model):
 
     @property
     def salary(self):
-        return Player.query.get(self.player_id).salary
+        player = Player.query.get(self.player_id)
+        return player.salary if player != None else 0
 
     def to_dict(self):
         return {

--- a/server/models.py
+++ b/server/models.py
@@ -15,6 +15,7 @@ class Player(db.Model):
     name = db.Column(db.Text)
     gender = db.Column(db.Text)
 
+    @property
     def is_male(self):
         return self.gender == 'male'
 
@@ -30,6 +31,10 @@ class Game(db.Model):
     home_score = db.Column(db.Integer)
     away_score = db.Column(db.Integer)
     points = db.Column(db.Text)
+
+    @property
+    def players(self):
+        return json.loads(self.home_roster) + json.loads(self.away_roster)
 
     def to_dict(self):
         return {

--- a/server/zuluru_sync.py
+++ b/server/zuluru_sync.py
@@ -39,7 +39,17 @@ def sync_team(session, id):
     team_name = soup.findAll('h2')[-1].get_text()
 
     team = get_or_create_team(team_name)
+
+    reset_team_players(team)
     sync_players(soup, team)
+
+
+def reset_team_players(team):
+    for current_player in Player.query.filter_by(team_id=team.id):
+        current_player.team_id = None
+        db.session.add(current_player)
+
+    db.session.commit()
 
 
 def sync_players(soup, team):
@@ -57,7 +67,6 @@ def sync_players(soup, team):
         name = p.get_text()
         gender = 'male' if g == 'Male' else 'female'
         update_or_create_player(zuluru_id, name, gender, team)
-
 
 
 def get_or_create_team(team_name):


### PR DESCRIPTION
closes #117

This PR finds which players are missing in `build_stats_response`. Absent players are then assigned a salary based on their history if they played before or the average of their gender on their team if there is no data.

After shipping this the production database needs to be reset, zuluru re-synced and then re-upload the games. (because @keatesc renamed his team 😠 )

before:
![image](https://user-images.githubusercontent.com/1965489/32632735-b6fb86dc-c572-11e7-8a21-04c9a00846e8.png)

after:
![image](https://user-images.githubusercontent.com/1965489/32632706-9951c7ae-c572-11e7-910d-b8b483a03c38.png)
