### PR TITLE
add caching to build_stats_response

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==0.12
 Flask-SQLAlchemy==2.2
+Flask-Caching==1.3.3
 Flask-Testing==0.6.2
 pytest==3.2.3
 requests==2.18.4

--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, send_from_directory
+from flask_caching import Cache
 
 from models import db, Game, Stats, Team, Player
 from utils import StatsCalculator
@@ -9,8 +10,12 @@ import datetime
 
 client_path = '../client/build'
 
+one_hour = 3600 # seconds
+cache_timeout = one_hour
+
 def create_app():
     app = Flask(__name__, static_folder=client_path)
+    cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
     if os.environ.get('APP_SETTINGS') == None:
         os.environ['APP_SETTINGS'] = 'config.DevelopmentConfig'
@@ -98,6 +103,7 @@ def create_app():
         return jsonify({"week": num, "stats": stats})
 
 
+    @cache.cached(timeout=cache_timeout)
     def build_stats_response(games):
         present_players = []
         stats = {}


### PR DESCRIPTION
I mentioned in #109 that we make heavy use of the DB to do build the stats response and #123 only added more load to the database. The way the response is constructed could be optimized but that might make it hard to understand which I don't want. Caching seems like a good solution here and Flask makes it pretty easy to do.  

I add https://github.com/sh4nks/flask-caching as a dependency and configured it to cache the `build_stats_response` function for 1 hour. We could go higher but it would delay the propagation of any fixes we deploy unless we manually clear the cache. By default Flask sets the cache key to `request.path` which is exactly what we need even though this is a function it is unique for each path. Note that a lot of google results, stack overflow etc refer to the deprecated https://pythonhosted.org/Flask-Cache/ I am using a Fork which has continued working on the library. It doesn't appear that anything in the API has changed.

I confirmed the cache is working by adding a print statement and refresh the route. It prints the first time and then never again.

```
build_stats_response
127.0.0.1 - - [11/Nov/2017 12:30:25] "GET /weeks/1 HTTP/1.1" 200 -
127.0.0.1 - - [11/Nov/2017 12:30:25] "GET /favicon.ico HTTP/1.1" 200 -
127.0.0.1 - - [11/Nov/2017 12:30:27] "GET /weeks/1 HTTP/1.1" 200 -
127.0.0.1 - - [11/Nov/2017 12:30:28] "GET /favicon.ico HTTP/1.1" 200 -
127.0.0.1 - - [11/Nov/2017 12:30:29] "GET /weeks/1 HTTP/1.1" 200 -
127.0.0.1 - - [11/Nov/2017 12:30:29] "GET /favicon.ico HTTP/1.1" 200 
```

@patrickkenzie @keatesc