### PR TITLE
Fix teams in all response

### DIFF
--- a/data/ocua_17-18/week1_game1.json
+++ b/data/ocua_17-18/week1_game1.json
@@ -12,7 +12,7 @@
     "Nick Theriault"
   ],
   "awayScore": 21,
-  "awayTeam": "The Sticklers (Forced Jokes and Dadpuns) (Sticks)",
+  "awayTeam": "The Sticklers (Forced Jokes and Dadpuns)",
   "homeRoster": [
     "Cassie Berquist",
     "Kristyn Berquist",
@@ -28,7 +28,7 @@
     "Darryl Payne"
   ],
   "homeScore": 21,
-  "homeTeam": "Strike",
+  "homeTeam": "2,4,6,8 (Even)",
   "league": "ocua_17-18",
   "points": [
     {

--- a/data/ocua_17-18/week1_game2.json
+++ b/data/ocua_17-18/week1_game2.json
@@ -14,7 +14,7 @@
     "Brian Perry(S)"
   ],
   "awayScore": 11,
-  "awayTeam": "Last Jedi",
+  "awayTeam": "Rudderless Pirate Ship",
   "homeRoster": [
     "Laura Chambers Storey",
     "Nicole MacDonald",

--- a/data/ocua_17-18/week2_game1.json
+++ b/data/ocua_17-18/week2_game1.json
@@ -13,7 +13,7 @@
     "Nick Theriault"
   ],
   "awayScore": 20,
-  "awayTeam": "The Sticklers (Forced Jokes and Dadpuns) (Sticks)",
+  "awayTeam": "The Sticklers (Forced Jokes and Dadpuns)",
   "homeRoster": [
     "Laura Chambers Storey",
     "Marie-Ange Gravel",

--- a/data/ocua_17-18/week2_game2.json
+++ b/data/ocua_17-18/week2_game2.json
@@ -26,7 +26,7 @@
     "Tom Newman"
   ],
   "homeScore": 24,
-  "homeTeam": "Strike",
+  "homeTeam": "2,4,6,8 (Even)",
   "league": "ocua_17-18",
   "points": [
     {

--- a/data/ocua_17-18/week2_game3.json
+++ b/data/ocua_17-18/week2_game3.json
@@ -28,7 +28,7 @@
     "Scott Higgins(S)"
   ],
   "homeScore": 17,
-  "homeTeam": "Last Jedi",
+  "homeTeam": "Rudderless Pirate Ship",
   "league": "ocua_17-18",
   "points": [
     {


### PR DESCRIPTION
I noticed that the `All` page didn't look right in the trade_simulator view. I looked into it and found a bug in how the team name is added into the response. If a player dropped out of the league they were still on the team because we only checked the game roster not the current roster. I added a flag to alter this logic. This is further evidence that this abstraction isn't great (discussion in #137).

After this change week 2 is identical to `all` because Zuluru has not changed since the data was recorded. After Trades get entered we can re-sync zuluru and `all` will show the new state.