### PR TITLE
API routing refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ install:
   - pip3 install -r requirements.txt
 script:
   - python3 server/test.py
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/client/src/Components/StatsProvider.js
+++ b/client/src/Components/StatsProvider.js
@@ -10,13 +10,13 @@ import StatsTable from './StatsTable'
 import Stats from '../Stores/Stats'
 
 const fetchWeeks = async () => {
-  let response = await fetch('/weeks')
+  let response = await fetch('/api/weeks')
   return await response.json()
 }
 
 const fetchStats = async (weekNum: number) => {
-  let url = `/weeks/${weekNum}`
-  if (weekNum === 0) url = '/stats'
+  let url = `/api/weeks/${weekNum}`
+  if (weekNum === 0) url = '/api/stats'
 
   let response = await fetch(url)
   let json = await response.json()

--- a/server/app.py
+++ b/server/app.py
@@ -70,7 +70,7 @@ def create_app():
 
 
     # API
-    @app.route('/teams')
+    @app.route('/api/teams')
     def teams():
         teams = {}
         for team in Team.query.all():
@@ -89,21 +89,21 @@ def create_app():
         return jsonify(teams)
 
 
-    @app.route('/weeks')
+    @app.route('/api/weeks')
     def weeks():
         query = db.session.query(Game.week.distinct().label("week"))
         weeks = [row.week for row in query.all()]
         return jsonify(sorted(weeks))
 
 
-    @app.route('/weeks/<num>')
+    @app.route('/api/weeks/<num>')
     def week(num):
         games = Game.query.filter_by(week=num)
         stats = build_stats_response(games)
         return jsonify({"week": num, "stats": stats})
 
 
-    @app.route('/stats')
+    @app.route('/api/stats')
     def stats():
         games = Game.query.order_by("week asc")
         stats = build_stats_response(games, is_all=True)
@@ -172,7 +172,7 @@ def create_app():
         return stats
 
 
-    @app.route('/games')
+    @app.route('/api/games')
     def games():
         games = []
         for game in Game.query.all():
@@ -181,7 +181,7 @@ def create_app():
         return jsonify(games)
 
 
-    @app.route('/games/<id>')
+    @app.route('/api/games/<id>')
     def game(id):
         game = Game.query.get(id)
         return jsonify(game.to_dict())


### PR DESCRIPTION
prefix all server routes with /api to avoid conflict with client side routing. This is blocking the Games Page #25

Unfortunately I'm pretty sure this change will require everyone to hard refresh after it deploys given the default behaviour of the create-react-app serviceWorker. What they'll experience is a never ending loading spinner to which refresh is probably what most people will do. 