### PR TITLE
add command line argument to seed production

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To sync teams from Zuluru run `heroku run python server/zuluru_sync.py`
 To backup the database (only the raw games data the rest is calculated by the app) run `python server/backup.py`
 
 
-To seed the production database uncomment the production url in `server/seed.py` and run the script locally `python server/seed.py`
+To seed the production database use the seed script with the `prod` command line argument `python server/seed.py prod`
 
 
 Contributing

--- a/server/seed.py
+++ b/server/seed.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
-import glob, os
+import glob, os, sys
 import requests
 
 # src = "data/test/"
 src = "data/ocua_17-18/"
 
 url = 'http://localhost:5000/upload'
-# url = 'https://parity-server.herokuapp.com/upload'
+if len(sys.argv) > 1 and sys.argv[1] == 'prod':
+    url = 'https://parity-server.herokuapp.com/upload'
 
 os.chdir(src)
 


### PR DESCRIPTION
Until we add the ability to edit stats from the app we might as well make the process of re-uploading everything easier.

The seed on production took a lot longer than I was expecting so we might need to do event editing  or fix the speed of re-seed before the end of the season