### PR TITLE
Only serialize points when required

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -195,7 +195,7 @@ def create_app():
     @app.route('/api/games/<id>')
     def game(id):
         game = Game.query.get(id)
-        return jsonify(game.to_dict())
+        return jsonify(game.to_dict(include_points=True))
 
 
     # Client

--- a/server/test.py
+++ b/server/test.py
@@ -631,6 +631,26 @@ class Test(TestCase):
             else:
                 assert normalized_stats["o_points_against"] == 0
 
+    def test_api_endpoints(self):
+        with open('data/test/mini_game2.json') as f:
+            game_str = f.read()
+
+        self.client.post('/upload', data=game_str, content_type='application/json')
+
+        response = self.client.get('/api/weeks')
+        assert response.status_code == 200
+
+        response = self.client.get('/api/weeks/1')
+        assert response.status_code == 200
+
+        response = self.client.get('/api/stats')
+        assert response.status_code == 200
+
+        response = self.client.get('/api/games')
+        assert response.status_code == 200
+
+        response = self.client.get('/api/games/1')
+        assert response.status_code == 200
 
 if __name__ == '__main__':
     os.environ['APP_SETTINGS'] = 'config.TestingConfig'


### PR DESCRIPTION
This sped up the average response time of `/games` on my machine from about 0.009 to 0.002. This also affects how much data is sent back by a fair amount which will have a higher impact on actual clients.