### PR TITLE
sync team zuluru id

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -75,6 +75,7 @@ def create_app():
         teams = {}
         for team in Team.query.all():
             teams[team.name] = {
+                'id': team.zuluru_id,
                 'players': [],
                 'malePlayers': [],
                 'femalePlayers': []

--- a/server/cli.py
+++ b/server/cli.py
@@ -112,11 +112,11 @@ def get_team_ids(session, league_id):
     return ids
 
 
-def sync_team(session, id):
-    soup = get_soup(session, team_path + str(id))
-    team_name = soup.findAll('h2')[-1].get_text()
+def sync_team(session, zuluru_id):
+    soup = get_soup(session, team_path + str(zuluru_id))
+    name = soup.findAll('h2')[-1].get_text()
 
-    team = get_or_create_team(team_name)
+    team = update_or_create_team(zuluru_id, name)
 
     reset_team_players(team)
     sync_players(soup, team)
@@ -147,17 +147,22 @@ def sync_players(soup, team):
         update_or_create_player(zuluru_id, name, gender, team)
 
 
-def get_or_create_team(team_name):
-    instance = Team.query.filter_by(name=team_name).first()
+def update_or_create_team(zuluru_id, name):
+    instance = Team.query.filter_by(name=name).first()
+
     if instance:
-        print('Found Team: ', team_name)
-        return instance
+        print('Found Team: ', name)
     else:
-        print('Creating Team: ', team_name)
-        instance = Team(name=team_name)
-        db.session.add(instance)
-        db.session.commit()
-        return instance
+        print('Creating Team: ', name)
+        instance = Team(name=name)
+
+    instance.name = name
+    instance.zuluru_id = zuluru_id
+
+    db.session.add(instance)
+    db.session.commit()
+
+    return instance
 
 
 def update_or_create_player(zuluru_id, name, gender, team):

--- a/server/models/team.py
+++ b/server/models/team.py
@@ -3,4 +3,5 @@ import json
 
 class Team(db.Model):
     id = db.Column(db.Integer, primary_key=True)
+    zuluru_id = db.Column(db.Integer, unique=True)
     name = db.Column(db.Text)


### PR DESCRIPTION
closes #145 

This adds a zuluru_id column to the teams table and fills it during a sync.

This table doesn't exist on production currently, I'll run this command before running the script to add the column:

```sql
ALTER TABLE team
ADD COLUMN zuluru_id INTEGER;
```

After I sync the teams again and get the zuluru_id's in the database then I will update the script to look up the team by ID in the first place (like we do for players). This will fix one aspect of team name changes being a pain. The android client still needs to be updated to use IDs to fully solve the problem.