### PR TITLE
update sync to use zuluru_id

### DIFF
--- a/server/cli.py
+++ b/server/cli.py
@@ -148,16 +148,15 @@ def sync_players(soup, team):
 
 
 def update_or_create_team(zuluru_id, name):
-    instance = Team.query.filter_by(name=name).first()
+    instance = Team.query.filter_by(zuluru_id=zuluru_id).first()
 
     if instance:
         print('Found Team: ', name)
     else:
         print('Creating Team: ', name)
-        instance = Team(name=name)
+        instance = Team(zuluru_id=zuluru_id)
 
     instance.name = name
-    instance.zuluru_id = zuluru_id
 
     db.session.add(instance)
     db.session.commit()


### PR DESCRIPTION
Teams on production now have the zuluru_id populated. Going forwards we should use this ID to update the record instead of name matching. This allows team name editing to work with sync. The Android client still uses names so the raw stats have to be updated if names are changed for now. Next step is to update android to know about IDs.