### PR TITLE
add local storage for player comparer and team dashboard

### DIFF
--- a/client/src/Components/ComparePlayers/index.js
+++ b/client/src/Components/ComparePlayers/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import _ from 'lodash'
+import ls from 'local-storage'
 import React, { Component } from 'react'
 import Stats from '../../Stores/Stats'
 import PlayerSelect from '../PlayerSelect'
@@ -40,16 +41,18 @@ export default class ComparePlayers extends Component {
     this.state = {
       week: this.props.week,
       stats: this.props.stats,
-      playerAName: players[0],
-      playerBName: players[1]
+      playerAName: ls.get('playerA') || players[0],
+      playerBName: ls.get('playerB') || players[1]
     }
   }
 
   playerAChanged (value: string) {
+    ls.set('playerA', value)
     this.setState({playerAName: value})
   }
 
   playerBChanged (value: string) {
+    ls.set('playerB', value)
     this.setState({playerBName: value})
   }
 

--- a/client/src/Components/StatsTable/SearchBar.js
+++ b/client/src/Components/StatsTable/SearchBar.js
@@ -19,8 +19,8 @@ export default class SearchBar extends Component {
 
   searchChange (event: any) {
     let query = event.target.value
-    this.props.changeFilter(query)
     ls.set(storageKey, query)
+    this.props.changeFilter(query)
   }
 
   render () {

--- a/client/src/Components/TeamDashboard/index.js
+++ b/client/src/Components/TeamDashboard/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import _ from 'lodash'
+import ls from 'local-storage'
 import React, { Component } from 'react'
 import Stats from '../../Stores/Stats'
 import MoneyCell from '../MoneyCell'
@@ -26,7 +27,7 @@ export default class TeamDashboard extends Component {
     this.state = {
       week: this.props.week,
       stats: this.props.stats,
-      team: this.props.stats.teamNames()[0]
+      team: ls.get('team') || this.props.stats.teamNames()[0]
     }
   }
 
@@ -34,11 +35,16 @@ export default class TeamDashboard extends Component {
     window.$('.dropdown-button').dropdown()
   }
 
+  teamChanged (teamName) {
+    ls.set('team', teamName)
+    this.setState({team: teamName})
+  }
+
   renderTeams (teams: Array<any>) {
     return _.map(teams, (team) => {
       return (
         <li key={team}>
-         <a onClick={() => { this.setState({team}) } }>
+         <a onClick={() => { this.teamChanged(team) }}>
             {team}
           </a>
         </li>


### PR DESCRIPTION
This makes it fewer clicks for GMs to inspect their own team since their browser will remember the last team they viewed. It also makes it easier to compare 2 players across multiple weeks.