### PR TITLE
expose the app variable from app.py and remove run.py

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn run:app --chdir server
+web: gunicorn app:app --chdir server

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Server Setup
 4. Create your database by running `python server/cli.py init_db` and then seed it with `python server/cli.py seed`
 5. You can inspect the server responses at `http://localhost:5000/api/weeks/1` and `http://localhost:5000/api/stats` etc.
 
-On production the python server serves a static build of the client. This can be tested locally by running yarn build and then visiting localhost:5000.
+On production the python server serves a static build of the client. This can be tested locally by running yarn build and then visiting localhost:5000 (note that you need to run the server from inside the server folder or the relative path to the client won't work. e.g. `cd server && python app.py`)
 
 
 Client Setup

--- a/server/app.py
+++ b/server/app.py
@@ -8,10 +8,7 @@ import os
 import json
 import datetime
 
-debug = False
-
 client_path = '../client/build'
-
 
 def create_app():
     app = Flask(__name__, static_folder=client_path)
@@ -32,6 +29,7 @@ def create_app():
         game = Game()
 
         # save response to file if debugging
+        debug = False
         if debug:
             now = datetime.datetime.now()
             fo = open('data/test/' + str(now) + '.json', 'w')

--- a/server/app.py
+++ b/server/app.py
@@ -15,12 +15,14 @@ client_path = '../client/build'
 
 def create_app():
     app = Flask(__name__, static_folder=client_path)
+
     cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
     if os.environ.get('APP_SETTINGS') == None:
         os.environ['APP_SETTINGS'] = 'config.DevelopmentConfig'
 
     app.config.from_object(os.environ['APP_SETTINGS'])
+
     db.init_app(app)
 
 
@@ -188,12 +190,14 @@ def create_app():
     return app
 
 
-# Development Server
+# Expose `app` for gunicorn
+app = create_app()
+
+
+# Boot server for Development / Test
 if __name__ == '__main__':
-    os.environ['APP_SETTINGS'] = 'config.DevelopmentConfig'
 
-    app = create_app()
-
+    # Auto create development database
     if app.config.get('DEVELOPMENT'):
         with app.app_context():
             db.create_all()

--- a/server/app.py
+++ b/server/app.py
@@ -8,188 +8,182 @@ import os
 import json
 import datetime
 
+
+# Settings
+if os.environ.get('APP_SETTINGS') == None:
+    os.environ['APP_SETTINGS'] = 'config.DevelopmentConfig'
+
 client_path = '../client/build'
 
-def create_app():
-    app = Flask(__name__, static_folder=client_path)
 
-    cache = Cache(app, config={'CACHE_TYPE': 'simple'})
-
-    if os.environ.get('APP_SETTINGS') == None:
-        os.environ['APP_SETTINGS'] = 'config.DevelopmentConfig'
-
-    app.config.from_object(os.environ['APP_SETTINGS'])
-
-    db.init_app(app)
+# Init
+app = Flask(__name__, static_folder=client_path)
+app.config.from_object(os.environ['APP_SETTINGS'])
+cache = Cache(app, config={'CACHE_TYPE': 'simple'})
+db.init_app(app)
 
 
-    # Upload
-    @app.route('/upload', methods=['POST'])
-    def upload():
-        game = Game()
+# Upload
+@app.route('/upload', methods=['POST'])
+def upload():
+    game = Game()
 
-        # save response to file if debugging
-        debug = False
-        if debug:
-            now = datetime.datetime.now()
-            fo = open('data/test/' + str(now) + '.json', 'w')
-            fo.write(json.dumps(request.json, indent=2, sort_keys=True))
-            fo.close()
+    # save response to file if debugging
+    debug = False
+    if debug:
+        now = datetime.datetime.now()
+        fo = open('data/test/' + str(now) + '.json', 'w')
+        fo.write(json.dumps(request.json, indent=2, sort_keys=True))
+        fo.close()
 
-        # save the game to the database
-        game.league = request.json['league']
-        game.week = request.json['week']
+    # save the game to the database
+    game.league = request.json['league']
+    game.week = request.json['week']
 
-        game.home_team = request.json['homeTeam']
-        game.away_team = request.json['awayTeam']
+    game.home_team = request.json['homeTeam']
+    game.away_team = request.json['awayTeam']
 
-        game.home_score = request.json['homeScore']
-        game.away_score = request.json['awayScore']
+    game.home_score = request.json['homeScore']
+    game.away_score = request.json['awayScore']
 
-        game.home_roster = json.dumps(request.json['homeRoster'])
-        game.away_roster = json.dumps(request.json['awayRoster'])
+    game.home_roster = json.dumps(request.json['homeRoster'])
+    game.away_roster = json.dumps(request.json['awayRoster'])
 
-        points = request.json['points']
-        game.points = json.dumps(points)
+    points = request.json['points']
+    game.points = json.dumps(points)
 
-        db.session.add(game)
-        db.session.commit()
+    db.session.add(game)
+    db.session.commit()
 
-        # calculate and save stats
-        stats = StatsCalculator(game.id, points).run()
-        for stat in stats:
-            db.session.add(stat[1])
-        db.session.commit()
+    # calculate and save stats
+    stats = StatsCalculator(game.id, points).run()
+    for stat in stats:
+        db.session.add(stat[1])
+    db.session.commit()
 
-        # clear the stats cache
-        cache.clear()
+    # clear the stats cache
+    cache.clear()
 
-        return ('', 201)
-
-
-    # API
-    @cache.cached()
-    @app.route('/api/teams')
-    def teams():
-        teams = {}
-        for team in Team.query.all():
-            teams[team.name] = {
-                'id': team.zuluru_id,
-                'players': [],
-                'malePlayers': [],
-                'femalePlayers': []
-            }
-            for player in Player.query.filter_by(team_id=team.id):
-                teams[team.name]['players'].append(player.name)
-                if player.is_male:
-                    teams[team.name]['malePlayers'].append(player.name)
-                else:
-                    teams[team.name]['femalePlayers'].append(player.name)
-
-        return jsonify(teams)
+    return ('', 201)
 
 
-    @cache.cached()
-    @app.route('/api/players')
-    def players():
-        query = Player.query.filter(Player.team_id != None)
-        players = [player.to_dict() for player in query.all()]
-        return jsonify(players)
-
-
-    @cache.cached()
-    @app.route('/api/games')
-    def games():
-        games = [game.to_dict() for game in Game.query.all()]
-        return jsonify(games)
-
-
-    @cache.cached()
-    @app.route('/api/games/<id>')
-    def game(id):
-        game = Game.query.get(id)
-        return jsonify(game.to_dict(include_points=True))
-
-
-    @cache.cached()
-    @app.route('/api/weeks')
-    def weeks():
-        query = db.session.query(Game.week.distinct().label("week"))
-        weeks = [row.week for row in query.all()]
-        return jsonify(sorted(weeks))
-
-
-    @cache.cached()
-    @app.route('/api/weeks/<num>')
-    def week(num):
-        games = Game.query.filter_by(week=num)
-        stats = build_stats_response(games)
-        return jsonify({"week": num, "stats": stats})
-
-
-    @cache.cached()
-    @app.route('/api/stats')
-    def stats():
-        games = Game.query.order_by("week asc")
-        stats = build_stats_response(games)
-        return jsonify({"week": 0, "stats": stats})
-
-
-    def build_stats_response(games):
-        stats = {}
-
-        # rollup stats per game
-        for game in games:
-            for player_stats in Stats.query.filter_by(game_id=game.id):
-                player = Player.query.get(player_stats.player_id)
-                data = player_stats.to_dict()
-
-                # aggregate all stats for the player
-                if player.name in stats:
-                    existing_data = stats[player.name]
-                    stats_to_average = ['pay', 'salary_per_point', 'o_efficiency', 'd_efficiency', 'total_efficiency']
-                    stats_to_sum = data.keys() - stats_to_average
-                    summed_stats = { s: data.get(s, 0) + existing_data.get(s, 0) for s in stats_to_sum }
-                    stats[player.name].update(summed_stats)
-                    averaged_stats = { s: data.get(s, 0) + existing_data.get(s, 0) for s in stats_to_average }
-                    stats[player.name].update(averaged_stats)
-                else:
-                    stats.update({player.name: data})
-
-                # set the team for the player
-                if "(S)" in player.name:
-                    team = "Substitute"
-                elif player.name in json.loads(game.home_roster):
-                    team = game.home_team
-                elif player.name in json.loads(game.away_roster):
-                    team = game.away_team
-                elif player.team_id:
-                    team = Team.query.get(player.team_id).name
-                else:
-                    team = 'Unknown'
-
-                stats[player.name].update({'team': team})
-
-        return stats
-
-
-    # Client
-    @app.route('/', defaults={'path': ''})
-    @app.route('/<path:path>')
-    def client(path):
-        if(path == ""):
-            return send_from_directory(client_path, 'index.html')
-        else:
-            if(os.path.exists(client_path + '/' + path)):
-                return send_from_directory(client_path, path)
+# API
+@cache.cached()
+@app.route('/api/teams')
+def teams():
+    teams = {}
+    for team in Team.query.all():
+        teams[team.name] = {
+            'id': team.zuluru_id,
+            'players': [],
+            'malePlayers': [],
+            'femalePlayers': []
+        }
+        for player in Player.query.filter_by(team_id=team.id):
+            teams[team.name]['players'].append(player.name)
+            if player.is_male:
+                teams[team.name]['malePlayers'].append(player.name)
             else:
-                return send_from_directory(client_path, 'index.html')
+                teams[team.name]['femalePlayers'].append(player.name)
 
-    return app
+    return jsonify(teams)
 
 
-# Expose `app` for gunicorn
-app = create_app()
+@cache.cached()
+@app.route('/api/players')
+def players():
+    query = Player.query.filter(Player.team_id != None)
+    players = [player.to_dict() for player in query.all()]
+    return jsonify(players)
+
+
+@cache.cached()
+@app.route('/api/games')
+def games():
+    games = [game.to_dict() for game in Game.query.all()]
+    return jsonify(games)
+
+
+@cache.cached()
+@app.route('/api/games/<id>')
+def game(id):
+    game = Game.query.get(id)
+    return jsonify(game.to_dict(include_points=True))
+
+
+@cache.cached()
+@app.route('/api/weeks')
+def weeks():
+    query = db.session.query(Game.week.distinct().label("week"))
+    weeks = [row.week for row in query.all()]
+    return jsonify(sorted(weeks))
+
+
+@cache.cached()
+@app.route('/api/weeks/<num>')
+def week(num):
+    games = Game.query.filter_by(week=num)
+    stats = build_stats_response(games)
+    return jsonify({"week": num, "stats": stats})
+
+
+@cache.cached()
+@app.route('/api/stats')
+def stats():
+    games = Game.query.order_by("week asc")
+    stats = build_stats_response(games)
+    return jsonify({"week": 0, "stats": stats})
+
+
+def build_stats_response(games):
+    stats = {}
+
+    # rollup stats per game
+    for game in games:
+        for player_stats in Stats.query.filter_by(game_id=game.id):
+            player = Player.query.get(player_stats.player_id)
+            data = player_stats.to_dict()
+
+            # aggregate all stats for the player
+            if player.name in stats:
+                existing_data = stats[player.name]
+                stats_to_average = ['pay', 'salary_per_point', 'o_efficiency', 'd_efficiency', 'total_efficiency']
+                stats_to_sum = data.keys() - stats_to_average
+                summed_stats = { s: data.get(s, 0) + existing_data.get(s, 0) for s in stats_to_sum }
+                stats[player.name].update(summed_stats)
+                averaged_stats = { s: data.get(s, 0) + existing_data.get(s, 0) for s in stats_to_average }
+                stats[player.name].update(averaged_stats)
+            else:
+                stats.update({player.name: data})
+
+            # set the team for the player
+            if "(S)" in player.name:
+                team = "Substitute"
+            elif player.name in json.loads(game.home_roster):
+                team = game.home_team
+            elif player.name in json.loads(game.away_roster):
+                team = game.away_team
+            elif player.team_id:
+                team = Team.query.get(player.team_id).name
+            else:
+                team = 'Unknown'
+
+            stats[player.name].update({'team': team})
+
+    return stats
+
+
+# Client
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def client(path):
+    if(path == ""):
+        return send_from_directory(client_path, 'index.html')
+    else:
+        if(os.path.exists(client_path + '/' + path)):
+            return send_from_directory(client_path, path)
+        else:
+            return send_from_directory(client_path, 'index.html')
 
 
 # Boot server for Development / Test

--- a/server/cli.py
+++ b/server/cli.py
@@ -8,7 +8,7 @@ import urllib.request, json, glob, sys, os, re
 from collections import defaultdict
 from flask_caching import Cache
 
-from app import db, create_app
+from app import app
 from models import db, Team, Player
 
 
@@ -20,8 +20,6 @@ def cli():
 @cli.command()
 def init_db():
     click.echo('Initializing database...')
-
-    app = create_app()
 
     with app.app_context():
         db.create_all()
@@ -88,8 +86,6 @@ def backup(week):
 
 @cli.command()
 def zuluru_sync():
-    app = create_app()
-
     with app.app_context():
         ZuluruSync().sync_teams(league_id=596)
 

--- a/server/run.py
+++ b/server/run.py
@@ -1,2 +1,0 @@
-from app import create_app
-app = create_app()

--- a/server/test.py
+++ b/server/test.py
@@ -6,13 +6,12 @@ import unittest
 import json
 import os
 
-from app import create_app
+from app import app
 from models import db, Game, Player, Stats
 
 class ServerTests(FlaskTest, SnapShotTest):
 
     def create_app(self):
-        app = create_app()
         return app
 
     def setUp(self):


### PR DESCRIPTION
The extra file run.py was bugging me so I re-worked things to remove it. 

The production webserver `gunicorn` needs an instance of the `app` exposed in a python file it loads. This is all run.py was used for. Initially I was trying to keep things inside `app.py` simpler but re-visiting I don't see any issue with this change.

I want to try and remove the `create_app` factory all together. The only snag is the test suite but I think I can get it to work still.