### PR TITLE
unregister the worker

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import 'materialize-css/dist/css/materialize.css'
 import './index.css'
 import App from './App'
-import registerServiceWorker from './registerServiceWorker'
+import { unregister } from './registerServiceWorker'
 
 ReactDOM.render(<App />, document.getElementById('root'))
-registerServiceWorker()
+unregister()


### PR DESCRIPTION
The client uses a service worker provided by the create react app framework https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#making-a-progressive-web-app.

This lets the app load assets immediately but comes with a few drawbacks. The page only updates assets on every N+1 load since it works like this:
* page is loaded from service worker cache
* worker refreshes asset cache in the background but does not reload
* next page load has the new assets

The problem is that our app is under pretty active development. It is annoying enough that new features don't get to users as fast but its problematic when we change the API since then users must refresh the page or the spinner shows forever or worse things crash.

This PR opts to remove the service worker by unregistering it. This process will take a while then we can remove the code. 

Alternatively while typing this out it occured to me that we could try and trigger a page refresh after the cache is refreshed. 