### PR TITLE
Tournament build flavor

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,17 +31,15 @@ android {
         signingConfig signingConfigs.release
     }
     useLibrary 'org.apache.http.legacy'
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            buildConfigField "String", "UPLOAD_URL", "\"https://parity-server.herokuapp.com/upload\""
-            buildConfigField "String", "TEAMS_URL", "\"https://parity-server.herokuapp.com/api/teams\""
             signingConfig signingConfigs.release
         }
         debug {
             buildConfigField "String", "UPLOAD_URL", "\"http://10.0.2.2:5000/upload\""
-            buildConfigField "String", "TEAMS_URL", "\"https://parity-server.herokuapp.com/api/teams\""
         }
     }
 
@@ -50,13 +48,20 @@ android {
         league {
             buildConfigField "Integer", "MAX_FEMALES", "2"
             buildConfigField "Integer", "MAX_MALES", "4"
+            def baseUrl = "https://parity-server.herokuapp.com"
+
+            buildConfigField "String", "UPLOAD_URL", "\"" + baseUrl + "/upload\""
+            buildConfigField "String", "TEAMS_URL", "\"" + baseUrl + "/api/teams\""
 
             dimension = "parity"
         }
         tournament {
             buildConfigField "Integer", "MAX_FEMALES", "2"
             buildConfigField "Integer", "MAX_MALES", "3"
+            def baseUrl = "https://parity-tournament.herokuapp.com"
 
+            buildConfigField "String", "UPLOAD_URL", "\"" + baseUrl + "/upload\""
+            buildConfigField "String", "TEAMS_URL", "\"" + baseUrl + "/api/teams\""
             dimension = "parity"
         }
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,10 +42,23 @@ android {
         debug {
             buildConfigField "String", "UPLOAD_URL", "\"http://10.0.2.2:5000/upload\""
             buildConfigField "String", "TEAMS_URL", "\"https://parity-server.herokuapp.com/api/teams\""
-            buildConfigField "String", "LOCAL_TEAMS_URL", "\"http://10.0.2.2:5000/api/teams\""
         }
     }
+
+    flavorDimensions( "parity" )
     productFlavors {
+        league {
+            buildConfigField "Integer", "MAX_FEMALES", "2"
+            buildConfigField "Integer", "MAX_MALES", "4"
+
+            dimension = "parity"
+        }
+        tournament {
+            buildConfigField "Integer", "MAX_FEMALES", "2"
+            buildConfigField "Integer", "MAX_MALES", "3"
+
+            dimension = "parity"
+        }
     }
     android.sourceSets {
         main.res.srcDirs = ['src/main/res', 'src/ColorPicker/res']

--- a/android/app/src/main/java/org/ocua/parity/SelectPlayers.java
+++ b/android/app/src/main/java/org/ocua/parity/SelectPlayers.java
@@ -211,7 +211,7 @@ public class SelectPlayers extends Activity {
             }
         }
 
-        int teamSize = 6;
+        int teamSize = BuildConfig.MAX_FEMALES + BuildConfig.MAX_MALES;
 
         boolean leftCorrectNumPlayers = leftPlayers.size() == teamSize;
         boolean rightCorrectNumPlayers = rightPlayers.size() == teamSize;


### PR DESCRIPTION
This adds build flavors to configure the android app for league use and the hat tournament (#179).

It sets new build constants for the gender ratio and the urls for loading rosters and submitting games.