### PR TITLE
Use auto sub detection and single "Add Player" button

### DIFF
--- a/android/app/src/main/java/org/ocua/parity/EditRosters.java
+++ b/android/app/src/main/java/org/ocua/parity/EditRosters.java
@@ -101,11 +101,6 @@ public class EditRosters extends Activity {
             }
         };
 
-
-
-        Button addPlayerButton = (Button) findViewById(R.id.btnAddPlayer);
-        addPlayerButton.setOnClickListener(addPlayerListener);
-
         Button addSubButton = (Button) findViewById(R.id.btnAddSubPlayer);
         addSubButton.setOnClickListener(addPlayerListener);
 
@@ -139,18 +134,16 @@ public class EditRosters extends Activity {
                     rightTeam.name
             };
 
-            final boolean isSubPlayer = v.getId() == R.id.btnAddSubPlayer;
-
             new AlertDialog.Builder(context)
                     .setTitle("Choose Team")
                     .setItems(teams, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int which) {
                             switch (which) {
                                 case 0:
-                                    addPlayer(input, leftTeam, isSubPlayer);
+                                    addPlayer(input, leftTeam);
                                     break;
                                 case 1:
-                                    addPlayer(input, rightTeam, isSubPlayer);
+                                    addPlayer(input, rightTeam);
                                     break;
                             }
                         }
@@ -158,24 +151,23 @@ public class EditRosters extends Activity {
         }
     };
 
-    private void addPlayer(final AutoCompleteTextView input, final Team team, boolean isSubPlayer) {
+    private void addPlayer(final AutoCompleteTextView input, final Team team) {
         input.setAdapter(new ArrayAdapter<>(
                 context,
                 android.R.layout.simple_dropdown_item_1line,
                 teams.allPlayers())
         );
 
-        final String playerSuffix = isSubPlayer ? "(S)" : "";
-        final String title = isSubPlayer ? "Add Substitute Player" : "Add Player";
-
         new AlertDialog.Builder(context)
-                .setTitle(title)
+                .setTitle("Add Player")
                 .setMessage("Player Name")
                 .setView(input)
                 .setPositiveButton("Ok", new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int whichButton) {
-                        final String playerName = input.getText().toString() + playerSuffix;
-                        final Gender gender = teams.getPlayerGender(input.getText().toString());
+                        String enteredPlayer = input.getText().toString();
+                        final Gender gender = teams.getPlayerGender(enteredPlayer);
+                        final String playerSuffix = team.isOnRoster(enteredPlayer) ? "" : "(S)";
+                        final String playerName = enteredPlayer + playerSuffix;
 
                         if (gender == Gender.Unknown) {
                             new AlertDialog.Builder(context)

--- a/android/app/src/main/java/org/ocua/parity/model/Team.java
+++ b/android/app/src/main/java/org/ocua/parity/model/Team.java
@@ -2,6 +2,7 @@ package org.ocua.parity.model;
 
 import java.util.ArrayList;
 import java.io.Serializable;
+import java.util.HashSet;
 
 public class Team implements Serializable {
     public String name = "";
@@ -10,22 +11,24 @@ public class Team implements Serializable {
     public ArrayList<String> arlGuys = new ArrayList<>();
     public ArrayList<String> arlGirls = new ArrayList<>();
 
+    private HashSet<String> roster = new HashSet<>();
+
     public Team(String teamName, int teamId) {
         this.name = teamName;
         this.id = teamId;
     }
 
     public void addPlayer(String playerName, Gender gender){
-        boolean isMale = (gender == Gender.Male);
-        addPlayer(playerName, isMale);
-    }
-
-    public void addPlayer(String playerName, Boolean isMale){
-        if (isMale){
+        if (gender == Gender.Male){
             arlGuys.add(playerName);
         } else {
             arlGirls.add(playerName);
         }
+    }
+
+    public void addRosterPlayer(String playerName, Boolean isMale){
+        addPlayer(playerName, isMale ? Gender.Male : Gender.Female);
+        roster.add(playerName);
     }
 
     public void removePlayer(String playerName, Boolean isMale) {
@@ -34,6 +37,10 @@ public class Team implements Serializable {
         } else {
             arlGirls.remove(playerName);
         }
+    }
+
+    public boolean isOnRoster(String playerName) {
+        return roster.contains(playerName);
     }
 
     public ArrayList<String> getRoster(){

--- a/android/app/src/main/java/org/ocua/parity/model/Teams.java
+++ b/android/app/src/main/java/org/ocua/parity/model/Teams.java
@@ -31,7 +31,7 @@ public class Teams implements Serializable {
 
                     String playerName = player.getString("name");
                     boolean isMale = player.getBoolean("is_male");
-                    team.addPlayer(playerName, isMale);
+                    team.addRosterPlayer(playerName, isMale);
                 }
 
                 teamsArray.add(team);

--- a/android/app/src/main/res/layout/activity_edit_rosters.xml
+++ b/android/app/src/main/res/layout/activity_edit_rosters.xml
@@ -102,18 +102,11 @@
         tools:context=".Stats">
 
         <Button
-            android:id="@+id/btnAddPlayer"
-            android:layout_width="fill_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="5"
-            android:text="Add Roster Player" />
-
-        <Button
             android:id="@+id/btnAddSubPlayer"
             android:layout_width="fill_parent"
             android:layout_height="match_parent"
             android:layout_weight="5"
-            android:text="Add Substitute" />
+            android:text="Add Player" />
 
         <Button
             android:id="@+id/btnFinish"


### PR DESCRIPTION
This removes the "Add Rostered Player" button to fix #213. This only uses automatic sub detection as the simplest option. We can investigate adding a UI toggle to override if needed as discussed in #213 - with the automatic Zuluru sync we haven't had any outdated rosters issues yet, so I think we can start with this.