### PR TITLE
Salary cap update

### DIFF
--- a/web/src/Components/TeamDashboard/index.js
+++ b/web/src/Components/TeamDashboard/index.js
@@ -31,7 +31,7 @@ export default class TeamDashboard extends Component {
     const salaries = _.map(sortedPlayers, (p) => p.salary);
     const teamSalary = _.sum(salaries);
     const { salaryCap, salaryFloor } = calcSalaryLimits(allPlayers);
-    const overCap = teamSalary > salaryCap;
+    const overCap = teamSalary > salaryCap || teamSalary < salaryFloor;
 
     return (
       <div>

--- a/web/src/Components/TeamDashboard/index.js
+++ b/web/src/Components/TeamDashboard/index.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 import TeamPicker from './TeamPicker'
 import Table from './Table'
 import Chart from './Chart'
-import { calcSalaryCap, calcSalaryFloor } from '../helpers'
+import { calcSalaryLimits } from '../helpers'
 
 export default class TeamDashboard extends Component {
   constructor (props) {
@@ -30,8 +30,7 @@ export default class TeamDashboard extends Component {
     const sortedPlayers = _.sortBy(teamPlayers, (p) => p.salary).reverse();
     const salaries = _.map(sortedPlayers, (p) => p.salary);
     const teamSalary = _.sum(salaries);
-    const salaryCap = calcSalaryCap(allPlayers);
-    const salaryFloor = calcSalaryFloor(allPlayers);
+    const { salaryCap, salaryFloor } = calcSalaryLimits(allPlayers);
     const overCap = teamSalary > salaryCap;
 
     return (

--- a/web/src/Components/TradeSimulator/Chart.js
+++ b/web/src/Components/TradeSimulator/Chart.js
@@ -14,15 +14,15 @@ export default class Chart extends Component {
         const teamPlayers = _.sortBy(players.filter((p) => p.team === team), (p) => p.salary)
         return teamPlayers.map((player, idx) => {
           const teamSalary = _.sum(_.map(teamPlayers, (p) => p.salary))
-          const overCap = teamSalary > salaryCap
+          const outsideLimits = teamSalary > salaryCap || teamSalary < salaryFloor
 
           return {
             type: 'bar',
             label: player.name,
             stack: team,
             data: [player.salary],
-            backgroundColor: overCap ? warnColors[idx] : colors[idx],
-            hoverBackgroundColor: overCap ? warnColors[idx] : colors[idx]
+            backgroundColor: outsideLimits ? warnColors[idx] : colors[idx],
+            hoverBackgroundColor: outsideLimits ? warnColors[idx] : colors[idx]
           }
         })
       }))

--- a/web/src/Components/TradeSimulator/Chart.js
+++ b/web/src/Components/TradeSimulator/Chart.js
@@ -6,7 +6,7 @@ import 'chartjs-plugin-annotation'
 
 export default class Chart extends Component {
   render () {
-    const { players, teamNames, salaryCap } = this.props
+    const { players, teamNames, salaryCap, salaryFloor } = this.props
 
     const data = {
       labels: teamNames,
@@ -67,6 +67,20 @@ export default class Chart extends Component {
             position: 'right',
             backgroundColor: 'black',
             content: 'Salary Cap',
+            enabled: true
+          }
+        },
+        {
+          type: 'line',
+          mode: 'horizontal',
+          scaleID: 'y-axis-0',
+          value: salaryFloor,
+          borderColor: 'black',
+          borderWidth: 2,
+          label: {
+            position: 'left',
+            backgroundColor: 'black',
+            content: 'Salary Floor',
             enabled: true
           }
         }]

--- a/web/src/Components/TradeSimulator/index.js
+++ b/web/src/Components/TradeSimulator/index.js
@@ -108,7 +108,7 @@ export default class TradeSimulator extends Component {
     const { players, playerA, playerB, trades } = this.state
     const teamNames = _.uniq(players.map(p => p.team));
     const playerNames = players.map(p => p.name)
-    const { salaryCap } = calcSalaryLimits(players);
+    const { salaryCap, salaryFloor } = calcSalaryLimits(players);
 
     return (
       <div>
@@ -146,6 +146,7 @@ export default class TradeSimulator extends Component {
             players={players}
             teamNames={teamNames}
             salaryCap={salaryCap}
+            salaryFloor={salaryFloor}
           />
         </div>
       </div>

--- a/web/src/Components/TradeSimulator/index.js
+++ b/web/src/Components/TradeSimulator/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import React, { Component } from 'react'
 import PlayerSelect from '../PlayerSelect'
 import Chart from './Chart'
-import { calcSalaryCap } from '../helpers'
+import { calcSalaryLimits } from '../helpers'
 
 export default class TradeSimulator extends Component {
   constructor (props) {
@@ -108,7 +108,7 @@ export default class TradeSimulator extends Component {
     const { players, playerA, playerB, trades } = this.state
     const teamNames = _.uniq(players.map(p => p.team));
     const playerNames = players.map(p => p.name)
-    const salaryCap = calcSalaryCap(players);
+    const { salaryCap } = calcSalaryLimits(players);
 
     return (
       <div>

--- a/web/src/Components/helpers.js
+++ b/web/src/Components/helpers.js
@@ -1,17 +1,15 @@
 import _ from 'lodash'
 
-export function calcSalaryCap(players) {
+export function calcSalaryLimits(players) {
   const numTeams = 10
   const salaryCapVariance = 0.02
   const salaries = _.map(players, (p) => p.salary)
-  return _.sum(salaries) / numTeams * (1 + salaryCapVariance)
-}
-
-export function calcSalaryFloor(players) {
-  const numTeams = 10
-  const salaryCapVariance = 0.02
-  const salaries = _.map(players, (p) => p.salary)
-  return _.sum(salaries) / numTeams * (1 - salaryCapVariance)
+  const salaryAvg = _.sum(salaries) / numTeams;
+  
+  return {
+    salaryCap: salaryAvg * (1 + salaryCapVariance),
+    salaryFloor: salaryAvg * (1 - salaryCapVariance),
+  }
 }
 
 export const colors = [

--- a/web/src/Components/helpers.js
+++ b/web/src/Components/helpers.js
@@ -1,15 +1,17 @@
 import _ from 'lodash'
 
 export function calcSalaryCap(players) {
-  const numTeams = 8
+  const numTeams = 10
+  const salaryCapVariance = 0.02
   const salaries = _.map(players, (p) => p.salary)
-  return _.sum(salaries) / numTeams * 1.01
+  return _.sum(salaries) / numTeams * (1 + salaryCapVariance)
 }
 
 export function calcSalaryFloor(players) {
-  const numTeams = 8
+  const numTeams = 10
+  const salaryCapVariance = 0.02
   const salaries = _.map(players, (p) => p.salary)
-  return _.sum(salaries) / numTeams * 0.99
+  return _.sum(salaries) / numTeams * (1 - salaryCapVariance)
 }
 
 export const colors = [


### PR DESCRIPTION
This PR updates the salary cap calculations in the app to account for the increase in teams from 8 to 10.

It also adds the salary cap floor to the trade simulator by request, and displays teams under the floor in warning colors.

The GMs this session have indicated that more tools and time saving information are a big priority, so including the floor on the trade sim page is helpful. The salary cap variance is likely to be a bit wider this season for the above reasons as well as exploring how a 3:3 gender ratio affects salary distribution, so there is a bit more space to display two lines on the chart.