### PR TITLE
Update menu links to spreadsheet

### DIFF
--- a/web/src/Components/SideNav.js
+++ b/web/src/Components/SideNav.js
@@ -1,13 +1,18 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router'
+import { Collapsible, CollapsibleItem } from 'react-materialize'
 
 class SideNav extends Component {
   render () {
     let forumUrl = 'https://www.ocua.ca/forum/33'
     let podcastUrl = 'https://soundcloud.com/user-640277634/sets/parity-podcast-season-2/s-Hka7a'
-    let spreadsheetUrl = 'https://docs.google.com/spreadsheets/d/1F46H8ZRGP8Jzj1zSW0PT8HerBZ_BlHI5T48A2vp34r0/edit?usp=sharing'
     let srcUrl = 'https://github.com/kevinhughes27/parity-server'
     let volunteerUrl = 'https://docs.google.com/spreadsheets/d/1lunhlXMe5_sefD6Dy9OCreQxMtEi2mzDrmHLhBD7Elo/edit?usp=sharing'
+
+    let spreadsheets = [
+      {name: '2017-2018', url: 'https://docs.google.com/spreadsheets/d/1F46H8ZRGP8Jzj1zSW0PT8HerBZ_BlHI5T48A2vp34r0' },
+      {name: '2018-2019', url: 'https://docs.google.com/spreadsheets/d/1KTFwydcZrVoHqEGej1uyZk8rO58RDr_1tUMIh08yZN8' }
+    ];
 
     return (
       <div>
@@ -29,7 +34,15 @@ class SideNav extends Component {
         <li><a href={volunteerUrl} target='_blank'>Volunteer</a></li>
         <li><a href={forumUrl} target='_blank'>Forum</a></li>
         <li><a href={podcastUrl} target='_blank'>Podcast</a></li>
-        <li><a href={spreadsheetUrl} target='_blank'>Spreadsheets</a></li>
+
+        <li>
+          <Collapsible>
+            <CollapsibleItem header="Spreadsheets">
+              {spreadsheets.map(sheet => <li><a href={sheet.url} target="_blank">{sheet.name}</a></li>)}
+            </CollapsibleItem>
+          </Collapsible>
+        </li>
+
         <li><a href={srcUrl} target='_blank'>Source Code</a></li>
       </div>
     )

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -7,3 +7,11 @@ html, body, #root {
   min-height: 100%;
   height: 100%;
 }
+
+.side-nav .collapsible-header {
+  padding: 0 32px
+}
+
+.side-nav .collapsible-body li a {
+  padding: 0 48px
+}


### PR DESCRIPTION
This PR adds the link for the 2018-2019 spreadsheet.

As part of that, it adds a collapsible section to the menu for the sheets so we can keep the link to previous years' spreadsheets.