### PR TITLE
Add new over-cap salary colour

### DIFF
--- a/web/src/Components/TeamDashboard/Chart.js
+++ b/web/src/Components/TeamDashboard/Chart.js
@@ -1,16 +1,26 @@
 import React, { Component } from 'react'
 import { Pie } from 'react-chartjs-2'
-import { colors, warnColors } from '../helpers'
+import { colors, warnColors, dangerColors } from '../helpers'
 
 export default class Chart extends Component {
   render () {
-    const { players, overCap } = this.props;
+    const { players, overCap, underFloor } = this.props;
+
+    let teamColors = colors;
+    if (overCap) {
+      teamColors = dangerColors;
+    } else if (underFloor) {
+      teamColors = warnColors;
+    }
+
+    const altColors = overCap ? warnColors : dangerColors;
+    const chartColors = players.map((p, i) => p.salary < 0 ? altColors[i] : teamColors[i]);
 
     const data = {
       labels: players.map (p => p.name),
       datasets: [{
-        data: players.map (p => p.salary),
-        backgroundColor: overCap ? warnColors : colors
+        data: players.map (p => Math.abs(p.salary)),
+        backgroundColor: chartColors
       }]
     };
 

--- a/web/src/Components/TeamDashboard/index.js
+++ b/web/src/Components/TeamDashboard/index.js
@@ -31,7 +31,8 @@ export default class TeamDashboard extends Component {
     const salaries = _.map(sortedPlayers, (p) => p.salary);
     const teamSalary = _.sum(salaries);
     const { salaryCap, salaryFloor } = calcSalaryLimits(allPlayers);
-    const overCap = teamSalary > salaryCap || teamSalary < salaryFloor;
+    const overCap = teamSalary > salaryCap;
+    const underFloor = teamSalary < salaryFloor;
 
     return (
       <div>
@@ -53,6 +54,7 @@ export default class TeamDashboard extends Component {
             <Chart
               players={sortedPlayers}
               overCap={overCap}
+              underFloor={underFloor}
             />
           </div>
         </div>

--- a/web/src/Components/TradeSimulator/Chart.js
+++ b/web/src/Components/TradeSimulator/Chart.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { Bar } from 'react-chartjs-2'
-import { colors, warnColors } from '../helpers'
+import { colors, warnColors, dangerColors } from '../helpers'
 import 'chartjs-plugin-annotation'
 
 export default class Chart extends Component {
@@ -14,15 +14,22 @@ export default class Chart extends Component {
         const teamPlayers = _.sortBy(players.filter((p) => p.team === team), (p) => p.salary)
         return teamPlayers.map((player, idx) => {
           const teamSalary = _.sum(_.map(teamPlayers, (p) => p.salary))
-          const outsideLimits = teamSalary > salaryCap || teamSalary < salaryFloor
+
+          let teamColors = colors;
+
+          if (teamSalary > salaryCap) {
+            teamColors = dangerColors;
+          } else if (teamSalary < salaryFloor) {
+            teamColors = warnColors;
+          }
 
           return {
             type: 'bar',
             label: player.name,
             stack: team,
             data: [player.salary],
-            backgroundColor: outsideLimits ? warnColors[idx] : colors[idx],
-            hoverBackgroundColor: outsideLimits ? warnColors[idx] : colors[idx]
+            backgroundColor: teamColors[idx],
+            hoverBackgroundColor: teamColors[idx]
           }
         })
       }))

--- a/web/src/Components/helpers.js
+++ b/web/src/Components/helpers.js
@@ -13,37 +13,49 @@ export function calcSalaryLimits(players) {
 }
 
 export const colors = [
-  '#E5F5E0',
-  '#D7EDD4',
-  '#C9E5C9',
-  '#BBDEBE',
-  '#ADD6B3',
-  '#9FCFA8',
-  '#91C79D',
-  '#84C092',
-  '#76B887',
-  '#68B07C',
-  '#5AA971',
-  '#4CA166',
-  '#3E9A5B',
-  '#309250',
-  '#238B45'
+  '#C8E6C9',
+  '#BDE0BE',
+  '#B2DAB3',
+  '#A7D4A8',
+  '#9CCF9E',
+  '#91C993',
+  '#85C388',
+  '#7ABD7D',
+  '#6FB772',
+  '#64B168',
+  '#59AC5D',
+  '#4EA652',
+  '#43A047'
 ]
 
 export const warnColors = [
   '#FFF9C4',
-  '#FEF6B9',
-  '#FEF4AF',
-  '#FEF1A5',
-  '#FEEF9B',
-  '#FEED90',
-  '#FEEA86',
-  '#FEE87C',
-  '#FDE672',
-  '#FDE368',
-  '#FDE15D',
-  '#FDDF53',
-  '#FDDC49',
-  '#FDDA3F',
+  '#FFF6B8',
+  '#FFF4AC',
+  '#FEF1A0',
+  '#FEEE94',
+  '#FEEB88',
+  '#FEE87D',
+  '#FEE671',
+  '#FEE365',
+  '#FDE059',
+  '#FDDE4D',
+  '#FDDB41',
   '#FDD835'
+]
+
+export const dangerColors = [
+  '#FFCDD2',
+  '#FDC1C5',
+  '#FBB4B8',
+  '#F8A8AB',
+  '#F69C9E',
+  '#F48F91',
+  '#F28384',
+  '#F07776',
+  '#EE6A69',
+  '#EB5E5C',
+  '#E9524F',
+  '#E74542',
+  '#E53935'
 ]


### PR DESCRIPTION
This adds a red colour to differentiate teams over the salary cap from teams under the salary floor. I ended up regenerating all the colours based on the current materialize colors so they'd all be consistent.

Fixes #235 as well, using the new colour on the TeamDashboard to indicate salaries that have been absolute valued.