### PR TITLE
Gender Filter for StatsPages

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -191,10 +191,7 @@ def build_stats_response(games):
                 team = 'Unknown'
 
             stats[player.name].update({'team': team})
-            if player.is_male:
-                stats[player.name].update({'gender': 'male'})
-            else:
-                stats[player.name].update({'gender': 'female'})
+            stats[player.name].update({'gender': player.gender})
 
     # resolve averages
     for player in stats:

--- a/server/app.py
+++ b/server/app.py
@@ -191,11 +191,16 @@ def build_stats_response(games):
                 team = 'Unknown'
 
             stats[player.name].update({'team': team})
+            if player.is_male:
+                stats[player.name].update({'gender': 'male'})
+            else:
+                stats[player.name].update({'gender': 'female'})
 
     # resolve averages
     for player in stats:
         for stat in stats_to_average:
             stats[player][stat] = stats[player][stat] / stats[player]['games_played']
+
         stats[player]['pay'] = round(stats[player]['pay'])
         stats[player]['salary_per_point'] = round(stats[player]['salary_per_point'])
         stats[player].pop('games_played')

--- a/server/app.py
+++ b/server/app.py
@@ -191,7 +191,9 @@ def build_stats_response(games):
                 team = 'Unknown'
 
             stats[player.name].update({'team': team})
-            stats[player.name].update({'gender': player.gender})
+
+            if player.gender:
+                stats[player.name].update({'gender': player.gender})
 
     # resolve averages
     for player in stats:

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:5000/",
+  "proxy": "https://parity-server.herokuapp.com",
   "dependencies": {
     "capitalize": "^1.0.0",
     "chart.js": "^2.7.1",

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
-  "proxy": "https://parity-server.herokuapp.com",
+  "proxy": "http://localhost:5000/",
   "dependencies": {
     "capitalize": "^1.0.0",
     "chart.js": "^2.7.1",

--- a/web/src/Components/ComparePlayers/index.js
+++ b/web/src/Components/ComparePlayers/index.js
@@ -44,7 +44,7 @@ export default class ComparePlayers extends Component {
     const { stats, playerAName, playerBName } = this.state
     const playerAStats = _.pick(stats[playerAName], STATS)
     const playerBStats = _.pick(stats[playerBName], STATS)
-    const playerNames = _.keys(stats)
+    const playerNames = _.keys(this.props.stats)
 
     return (
       <div>

--- a/web/src/Components/GenderFilter.js
+++ b/web/src/Components/GenderFilter.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import { Dropdown, NavItem } from 'react-materialize'
+import capitalize from 'capitalize'
+
+export default class GenderFilter extends Component {
+  filterOption (display, filter) {
+    return (
+      <NavItem key={filter} onClick={() => { this.props.onChange(filter)}}>
+        {display}
+      </NavItem>
+    )
+  }
+
+  render () {
+    const { filter } = this.props;
+    return (
+      <Dropdown trigger={
+        <a className='dropdown-button'>
+          Gender: {capitalize(filter) || 'Any'}
+          <i className='material-icons right'>arrow_drop_down</i>
+        </a>
+      }>
+        {this.filterOption('Any', '')}
+        {this.filterOption('Female', 'female')}
+        {this.filterOption('Male', 'male')}
+      </Dropdown>
+    )
+  }
+}

--- a/web/src/Components/StatsPage.js
+++ b/web/src/Components/StatsPage.js
@@ -90,10 +90,10 @@ class StatsProvider extends Component {
     const stats = this.filteredStats(filter, this.state.stats)
 
     return (
-      <div className="container" style={{height: '100%', minHeight: '100%'}}>
+      <div className="container" key={filter} style={{height: '100%', minHeight: '100%'}}>
         { this.props.children
           ? React.cloneElement(this.props.children, {week: week, stats: stats})
-          : <StatsTable key={filter} week={week} stats={stats}/>
+          : <StatsTable week={week} stats={stats}/>
         }
       </div>
     )

--- a/web/src/Components/StatsPage.js
+++ b/web/src/Components/StatsPage.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import TopNav from './TopNav'
 import Loading from './Loading'
 import WeekPicker from './WeekPicker'
+import GenderFilter from './GenderFilter'
 import StatsTable from './StatsTable'
 
 const fetchWeeks = async () => {
@@ -29,7 +30,8 @@ class StatsProvider extends Component {
       loading: true,
       weeks: [],
       week: 0,
-      stats: {}
+      stats: {},
+      filter: '',
     }
   }
 
@@ -42,6 +44,16 @@ class StatsProvider extends Component {
     })()
   }
 
+  filteredStats(filter, stats) {
+    if (filter === '') {
+      return stats;
+    }
+
+    return _.pickBy(stats, (statEntry) => {
+      return statEntry.gender === filter;
+    })
+  }
+
   weekChange (week) {
     (async () => {
       this.setState({week, loading: true})
@@ -50,14 +62,21 @@ class StatsProvider extends Component {
     })()
   }
 
+  genderChange (filter) {
+    this.setState({ filter })
+  }
+
   renderNav () {
     const week = this.state.week
     const weeks = [0, ...this.state.weeks]
     const weekChange = this.weekChange.bind(this)
+    const genderFilter = this.state.filter
+    const genderChange = this.genderChange.bind(this)
 
     return (
       <TopNav>
-        <ul className="right">
+        <ul className="right top-nav">
+          <GenderFilter filter={genderFilter} onChange={genderChange} />
           <WeekPicker week={week} weeks={weeks} onChange={weekChange} />
         </ul>
       </TopNav>
@@ -67,13 +86,14 @@ class StatsProvider extends Component {
   renderMain () {
     if (this.state.loading) return (<Loading />)
 
-    const { week, stats } = this.state
+    const { week, filter } = this.state
+    const stats = this.filteredStats(filter, this.state.stats)
 
     return (
       <div className="container" style={{height: '100%', minHeight: '100%'}}>
         { this.props.children
           ? React.cloneElement(this.props.children, {week: week, stats: stats})
-          : <StatsTable week={week} stats={stats}/>
+          : <StatsTable key={filter} week={week} stats={stats}/>
         }
       </div>
     )

--- a/web/src/Components/StatsPage.js
+++ b/web/src/Components/StatsPage.js
@@ -90,7 +90,7 @@ class StatsProvider extends Component {
     const stats = this.filteredStats(filter, this.state.stats)
 
     return (
-      <div className="container" key={filter} style={{height: '100%', minHeight: '100%'}}>
+      <div className="container" style={{height: '100%', minHeight: '100%'}}>
         { this.props.children
           ? React.cloneElement(this.props.children, {week: week, stats: stats})
           : <StatsTable week={week} stats={stats}/>

--- a/web/src/Components/StatsTable/index.js
+++ b/web/src/Components/StatsTable/index.js
@@ -40,17 +40,8 @@ columnsMeta.push({
 })
 
 export default class StatsTable extends Component {
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      week: this.props.week,
-      stats: this.props.stats
-    }
-  }
-
   render () {
-    const stats = this.state.stats
+    const stats = this.props.stats
     const statsArray = _.map(_.keys(stats), (k) => {
       return { name: k, ...stats[k] }
     })

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -15,3 +15,7 @@ html, body, #root {
 .side-nav .collapsible-body li a {
   padding: 0 48px
 }
+
+.top-nav > * {
+  display: inline-block;
+}


### PR DESCRIPTION
This adds a dropdown in the top nav bar to filter the data in StatsPage components by player gender. I'm not sure if there's a nicer way to display the gender and week dropdowns than this, and if we add more filtering options in the future we should probably rework it.

To support the filtering, I added a gender field to the API's stats response.

One quirk from this: when filtering by gender,  substitute players are filtered out because their genders aren't recorded. It would be a much bigger change to pass the gender from the Android app when uploading and to record it while processing the stats. This is probably even a good thing for the leaderboards, it's possible we should have the option to remove subs from those anyway. 

Resolves #242 