### PR TITLE
Absent Player Fallback Salaries

### DIFF
--- a/server/models/player.py
+++ b/server/models/player.py
@@ -60,14 +60,14 @@ class Player(db.Model):
             return self.fallback_salary
 
         if self.team_id:
-            team_mates = Player.query.filter_by(team_id=self.team_id).all()
-            same_gender_salaries = [p.salary for p in team_mates if p.is_male == self.is_male and p.has_stats]
+            all_players = Player.query.all()
+            same_gender_salaries = [p.salary for p in all_players if p.is_male == self.is_male and p.has_stats]
 
             if len(same_gender_salaries) == 0:
                 return 0
             else:
                 avg_salary = sum(same_gender_salaries) / len(same_gender_salaries)
-                return avg_salary
+                return round(avg_salary)
         else:
             return 0
 

--- a/server/models/player.py
+++ b/server/models/player.py
@@ -59,17 +59,14 @@ class Player(db.Model):
         if self.fallback_salary:
             return self.fallback_salary
 
-        if self.team_id:
-            all_players = Player.query.all()
-            same_gender_salaries = [p.salary for p in all_players if p.is_male == self.is_male and p.has_stats]
+        all_players = Player.query.all()
+        same_gender_salaries = [p.salary for p in all_players if p.is_male == self.is_male and p.has_stats]
 
-            if len(same_gender_salaries) == 0:
-                return 0
-            else:
-                avg_salary = sum(same_gender_salaries) / len(same_gender_salaries)
-                return round(avg_salary)
-        else:
+        if len(same_gender_salaries) == 0:
             return 0
+        else:
+            avg_salary = sum(same_gender_salaries) / len(same_gender_salaries)
+            return round(avg_salary)
 
     def to_dict(self):
         return {

--- a/server/models/player.py
+++ b/server/models/player.py
@@ -9,6 +9,7 @@ class Player(db.Model):
     team_id = db.Column(db.Integer, db.ForeignKey('team.id'))
     name = db.Column(db.Text)
     gender = db.Column(db.Text)
+    fallback_salary = db.Column(db.Integer)
 
     @property
     def is_male(self):
@@ -55,6 +56,9 @@ class Player(db.Model):
 
     @property
     def _fallback_salary(self):
+        if self.fallback_salary:
+            return self.fallback_salary
+
         if self.team_id:
             team_mates = Player.query.filter_by(team_id=self.team_id).all()
             same_gender_salaries = [p.salary for p in team_mates if p.is_male == self.is_male and p.has_stats]


### PR DESCRIPTION
This has a couple of salary tweaks for session 2. 

There's an option to give players a default salary - the league wants to give players without stats their salary from session 1 if known. The fallback salary gets overridden once the player gets stats.

The regular fallback salary calculation is also changed to use league-wide gender average, instead of team-only. There are some blank spots this session and the decision is to go with stable salaries for absent players.