### PR TITLE
Sort teams by name

### DIFF
--- a/web/src/Components/TeamDashboard/TeamPicker.js
+++ b/web/src/Components/TeamDashboard/TeamPicker.js
@@ -20,7 +20,7 @@ export default class TeamPicker extends Component {
 
   render () {
     const { team, allPlayers, onChange }  = this.props;
-    const teams = _.uniq(allPlayers.map(p => p.team));
+    const teams = _.sortBy(_.uniq(allPlayers.map(p => p.team)));
 
     return (
       <div>

--- a/web/src/Components/TradeSimulator/index.js
+++ b/web/src/Components/TradeSimulator/index.js
@@ -106,7 +106,7 @@ export default class TradeSimulator extends Component {
 
   render () {
     const { players, playerA, playerB, trades } = this.state
-    const teamNames = _.uniq(players.map(p => p.team));
+    const teamNames = _.sortBy(_.uniq(players.map(p => p.team)));
     const playerNames = players.map(p => p.name)
     const { salaryCap, salaryFloor } = calcSalaryLimits(players);
 


### PR DESCRIPTION
This sorts the teams by name on the trade simulator and the dropdown on the team dashboard. Trading players sometimes resulted in the teams changing places in the UI.