### PR TITLE
Fix CI Error with SQL Alchemy 1.3

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -153,7 +153,7 @@ def week(num):
 @cache.cached()
 @app.route('/api/stats')
 def stats():
-    games = Game.query.order_by("week asc")
+    games = Game.query.order_by(Game.week.asc())
     stats = build_stats_response(games)
     return jsonify({"week": 0, "stats": stats})
 


### PR DESCRIPTION
This replaces the text value for the game query in `/api/stats` with fields from the model. 

SQL Alchemy 1.3 removed automatic coercion of text passed to queries: [](https://docs.sqlalchemy.org/en/latest/changelog/changelog_13.html#change-1.3.0b3-sql). That caused the CI build to fail when it grabbed the updated version.
