### PR TITLE
Add holds and breaks to stats table

### DIFF
--- a/web/src/views/StatsTable.js
+++ b/web/src/views/StatsTable.js
@@ -62,6 +62,18 @@ const columnsMeta = [
     searchable: false
   },
   {
+    field: 'o_efficiency',
+    title: 'Holds',
+    searchable: false,
+    render: rowData => rowData.o_points_for + '/' + (rowData.o_points_against + rowData.o_points_for)
+  },
+  {
+    field: 'd_efficiency',
+    title: 'Breaks',
+    searchable: false,
+    render: rowData => rowData.d_points_for + '/' + (rowData.d_points_against + rowData.d_points_for)
+  },
+  {
     field: 'pay',
     title: 'Pay',
     type: 'currency',


### PR DESCRIPTION
This adds columns for holds (o points for) and breaks (d points against) to the stats table. For context, it displays the values as scored / attempted (so x_points_for / x_points_for + x_points_against). It also sorts by the efficiency, because that should account for blowouts vs close games.

I'm not sure if those choices are the clearest options, but it's handy to show the data now that it's part of the salary calculations!