### PR TITLE
League picker site wide + persistent choice

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:5000",
+  "proxy": "https://parity-server.herokuapp.com",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -31,7 +31,7 @@ class App extends React.Component {
     return (
       <Router history={browserHistory} onUpdate={logPageView}>
         <Route exact path="/games" component={GamesList} />
-        <Route path="/games/:gameId" component={Game} />
+        <Route path="/:leagueId/games/:gameId" component={Game} />
 
         <Route exact path="/" >
           <StatsPage>

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -1,6 +1,15 @@
 import 'whatwg-fetch'
+import ls from 'local-storage'
 
-const defaultLeague = "10"
+const leagueKey = 'currentLeague'
+
+const currentLeague = () => {
+  return ls.get(leagueKey) || '10'
+}
+
+const setLeague = (league) => {
+  ls.set(leagueKey, league)
+}
 
 const dataCache = {}
 
@@ -26,32 +35,32 @@ const cachedFetch = (url, _options) => {
   })
 }
 
-const fetchGames = async (league = defaultLeague) => {
+const fetchGames = async (league) => {
   const response = await cachedFetch(`/api/${league}/games`)
   return await response.json()
 }
 
-const fetchGame = async (gameId, league = defaultLeague) => {
+const fetchGame = async (gameId, league) => {
   const response = await cachedFetch(`/api/${league}/games/${gameId}`)
   return await response.json()
 }
 
-const fetchLeagues = async (league = defaultLeague) => {
+const fetchLeagues = async () => {
   const response = await cachedFetch(`/api/leagues`)
   return await response.json()
 }
 
-const fetchPlayers = async (league = defaultLeague) => {
+const fetchPlayers = async (league) => {
   const response = await cachedFetch(`/api/${league}/players`)
   return await response.json()
 }
 
-const fetchWeeks = async (league = defaultLeague) => {
+const fetchWeeks = async (league) => {
   const response = await cachedFetch(`/api/${league}/weeks`)
   return await response.json()
 }
 
-const fetchStats = async (weekNum, league = defaultLeague) => {
+const fetchStats = async (weekNum, league) => {
   let url = `/api/${league}/weeks/${weekNum}`
   if (weekNum === 0) url = `/api/${league}/stats`
 
@@ -62,6 +71,8 @@ const fetchStats = async (weekNum, league = defaultLeague) => {
 }
 
 export {
+  currentLeague,
+  setLeague,
   fetchGames,
   fetchGame,
   fetchLeagues,

--- a/web/src/components/LeaguePicker.js
+++ b/web/src/components/LeaguePicker.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { withStyles } from '@material-ui/styles'
 import MenuItem from '@material-ui/core/MenuItem'
 import Select from '@material-ui/core/Select'
+import { currentLeague, setLeague, fetchLeagues } from '../api'
 import { map } from 'lodash'
 
 const styles = {
@@ -16,6 +17,19 @@ const styles = {
 }
 
 class LeaguePicker extends Component {
+  state = {
+    loading: true,
+    leagues: [],
+    league: currentLeague(),
+  }
+
+  componentDidMount () {
+    return (async () => {
+      const leagues = await fetchLeagues()
+      this.setState({leagues, loading: false})
+    })()
+  }
+
   renderLeagues (leagues) {
     return map(leagues, (league) => {
       return (
@@ -26,14 +40,24 @@ class LeaguePicker extends Component {
     })
   }
 
+  onChange = (ev) => {
+    const league = ev.target.value
+    setLeague(league)
+    this.setState({league})
+    this.props.onChange(league)
+  }
+
   render () {
-    const { classes, league, leagues, onChange } = this.props
+    const { classes } = this.props
+    const { league, leagues, loading } = this.state
+
+    if (loading) return null
 
     return (
       <div style={{paddingRight: 20}}>
         <Select
           value={league}
-          onChange={onChange}
+          onChange={this.onChange}
           classes={{ root: classes.selectRoot }}
           disableUnderline
           inputProps={{

--- a/web/src/helpers.js
+++ b/web/src/helpers.js
@@ -1,10 +1,10 @@
-import _ from 'lodash'
+import { map, sum } from 'lodash'
 
 export function calcSalaryLimits(players) {
   const numTeams = 10
   const salaryCapVariance = 0.02
-  const salaries = _.map(players, (p) => p.salary)
-  const salaryAvg = _.sum(salaries) / numTeams;
+  const salaries = map(players, (p) => p.salary)
+  const salaryAvg = sum(salaries) / numTeams;
 
   return {
     salaryCap: salaryAvg * (1 + salaryCapVariance),

--- a/web/src/helpers.js
+++ b/web/src/helpers.js
@@ -1,7 +1,7 @@
-import { map, sum } from 'lodash'
+import { map, sum, uniq } from 'lodash'
 
 export function calcSalaryLimits(players) {
-  const numTeams = 10
+  const numTeams = uniq(players.map(p => p.team)).length
   const salaryCapVariance = 0.02
   const salaries = map(players, (p) => p.salary)
   const salaryAvg = sum(salaries) / numTeams;

--- a/web/src/views/Game/index.js
+++ b/web/src/views/Game/index.js
@@ -22,10 +22,11 @@ export default class Game extends Component {
   }
 
   componentDidMount () {
+    const leagueId = this.props.match.params.leagueId
     const gameId = this.props.match.params.gameId
 
     return (async () => {
-      const game = await fetchGame(gameId)
+      const game = await fetchGame(gameId, leagueId)
       this.setState({game, loading: false})
     })()
   }

--- a/web/src/views/GamesList/index.js
+++ b/web/src/views/GamesList/index.js
@@ -9,7 +9,7 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import { groupBy } from 'lodash'
-import { fetchLeagues, fetchGames } from '../../api'
+import { currentLeague, fetchGames } from '../../api'
 
 const styles = {
   list: {
@@ -22,33 +22,27 @@ const styles = {
   }
 }
 
-const defaultLeague = 10
-
 class GamesList extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
       loading: true,
-      leagues: [],
-      league: '',
       games: []
     }
   }
 
   componentDidMount () {
-    const league = defaultLeague
+    const league = currentLeague()
     return (async () => {
-      const leagues = await fetchLeagues()
       const games = await fetchGames(league)
-      this.setState({leagues, league, games, loading: false})
+      this.setState({games, loading: false})
     })()
   }
 
-  leagueChange (event) {
-    const league = event.target.value
+  leagueChange (league) {
     return (async () => {
-      this.setState({league, loading: true})
+      this.setState({loading: true})
       const games = await fetchGames(league)
       this.setState({ games, loading: false })
     })()
@@ -82,7 +76,6 @@ class GamesList extends Component {
   }
 
   renderGame (game) {
-    debugger
     return (
       <NavLink key={game.id} to={`${game.league_id}/games/${game.id}`} style={styles.listItem}>
         <ListItem divider button>
@@ -111,14 +104,12 @@ class GamesList extends Component {
   }
 
   render () {
-    const league = this.state.league
-    const leagues = [...this.state.leagues]
     const leagueChange = this.leagueChange.bind(this)
 
     return (
       <React.Fragment>
         <TopNav>
-          <LeaguePicker league={league} leagues={leagues} onChange={leagueChange} />
+          <LeaguePicker onChange={leagueChange} />
         </TopNav>
         { this.renderMain() }
       </React.Fragment>

--- a/web/src/views/GamesList/index.js
+++ b/web/src/views/GamesList/index.js
@@ -3,12 +3,13 @@ import { withStyles } from '@material-ui/styles'
 import { NavLink } from 'react-router-dom'
 import TopNav from '../../layout/TopNav'
 import Loading from '../../components/Loading'
+import LeaguePicker from '../../components/LeaguePicker'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import { groupBy } from 'lodash'
-import { fetchGames } from '../../api'
+import { fetchLeagues, fetchGames } from '../../api'
 
 const styles = {
   list: {
@@ -21,20 +22,35 @@ const styles = {
   }
 }
 
+const defaultLeague = 10
+
 class GamesList extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
       loading: true,
+      leagues: [],
+      league: '',
       games: []
     }
   }
 
   componentDidMount () {
-    (async () => {
-      const games = await fetchGames()
-      this.setState({games, loading: false})
+    const league = defaultLeague
+    return (async () => {
+      const leagues = await fetchLeagues()
+      const games = await fetchGames(league)
+      this.setState({leagues, league, games, loading: false})
+    })()
+  }
+
+  leagueChange (event) {
+    const league = event.target.value
+    return (async () => {
+      this.setState({league, loading: true})
+      const games = await fetchGames(league)
+      this.setState({ games, loading: false })
     })()
   }
 
@@ -66,8 +82,9 @@ class GamesList extends Component {
   }
 
   renderGame (game) {
+    debugger
     return (
-      <NavLink key={game.id} to={`/games/${game.id}`} style={styles.listItem}>
+      <NavLink key={game.id} to={`${game.league_id}/games/${game.id}`} style={styles.listItem}>
         <ListItem divider button>
           <ListItemText>
             { game.homeTeam } vs { game.awayTeam }
@@ -94,9 +111,15 @@ class GamesList extends Component {
   }
 
   render () {
+    const league = this.state.league
+    const leagues = [...this.state.leagues]
+    const leagueChange = this.leagueChange.bind(this)
+
     return (
       <React.Fragment>
-        <TopNav />
+        <TopNav>
+          <LeaguePicker league={league} leagues={leagues} onChange={leagueChange} />
+        </TopNav>
         { this.renderMain() }
       </React.Fragment>
     )

--- a/web/src/views/SalaryPage.js
+++ b/web/src/views/SalaryPage.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react'
 import TopNav from '../layout/TopNav'
 import Loading from '../components/Loading'
-import { fetchPlayers } from "../api"
+import LeaguePicker from '../components/LeaguePicker'
+import { fetchLeagues, fetchPlayers } from "../api"
+
+const defaultLeague = 10
 
 class SalaryProvider extends Component {
   constructor (props) {
@@ -9,14 +12,27 @@ class SalaryProvider extends Component {
 
     this.state = {
       loading: true,
+      leagues: [],
+      league: '',
       players: [],
     }
   }
 
   componentDidMount () {
-    (async () => {
-      const players = await fetchPlayers()
-      this.setState({players, loading: false})
+    const league = defaultLeague
+    return (async () => {
+      const leagues = await fetchLeagues()
+      const players = await fetchPlayers(league)
+      this.setState({leagues, league, players, loading: false})
+    })()
+  }
+
+  leagueChange (event) {
+    const league = event.target.value
+    return (async () => {
+      this.setState({league, loading: true})
+      const players = await fetchPlayers(league)
+      this.setState({ players, loading: false })
     })()
   }
 
@@ -33,9 +49,15 @@ class SalaryProvider extends Component {
   }
 
   render () {
+    const league = this.state.league
+    const leagues = [...this.state.leagues]
+    const leagueChange = this.leagueChange.bind(this)
+
     return (
       <div>
-        <TopNav />
+        <TopNav>
+          <LeaguePicker league={league} leagues={leagues} onChange={leagueChange} />
+        </TopNav>
         { this.renderMain() }
       </div>
     )

--- a/web/src/views/SalaryPage.js
+++ b/web/src/views/SalaryPage.js
@@ -2,9 +2,7 @@ import React, { Component } from 'react'
 import TopNav from '../layout/TopNav'
 import Loading from '../components/Loading'
 import LeaguePicker from '../components/LeaguePicker'
-import { fetchLeagues, fetchPlayers } from "../api"
-
-const defaultLeague = 10
+import { currentLeague, fetchPlayers } from "../api"
 
 class SalaryProvider extends Component {
   constructor (props) {
@@ -12,25 +10,21 @@ class SalaryProvider extends Component {
 
     this.state = {
       loading: true,
-      leagues: [],
-      league: '',
       players: [],
     }
   }
 
   componentDidMount () {
-    const league = defaultLeague
+    const league = currentLeague()
     return (async () => {
-      const leagues = await fetchLeagues()
       const players = await fetchPlayers(league)
-      this.setState({leagues, league, players, loading: false})
+      this.setState({players, loading: false})
     })()
   }
 
-  leagueChange (event) {
-    const league = event.target.value
+  leagueChange (league) {
     return (async () => {
-      this.setState({league, loading: true})
+      this.setState({loading: true})
       const players = await fetchPlayers(league)
       this.setState({ players, loading: false })
     })()
@@ -49,14 +43,12 @@ class SalaryProvider extends Component {
   }
 
   render () {
-    const league = this.state.league
-    const leagues = [...this.state.leagues]
     const leagueChange = this.leagueChange.bind(this)
 
     return (
       <div>
         <TopNav>
-          <LeaguePicker league={league} leagues={leagues} onChange={leagueChange} />
+          <LeaguePicker onChange={leagueChange} />
         </TopNav>
         { this.renderMain() }
       </div>

--- a/web/src/views/StatsPage.js
+++ b/web/src/views/StatsPage.js
@@ -5,9 +5,7 @@ import LeaguePicker from '../components/LeaguePicker'
 import WeekPicker from '../components/WeekPicker'
 import GenderFilter from '../components/GenderFilter'
 import { last, pickBy } from 'lodash'
-import { fetchLeagues, fetchWeeks, fetchStats } from "../api"
-
-const defaultLeague = 10
+import { currentLeague, fetchWeeks, fetchStats } from "../api"
 
 class StatsProvider extends Component {
   constructor (props) {
@@ -15,8 +13,6 @@ class StatsProvider extends Component {
 
     this.state = {
       loading: true,
-      leagues: [],
-      league: '',
       weeks: [],
       week: 0,
       stats: {},
@@ -25,20 +21,18 @@ class StatsProvider extends Component {
   }
 
   componentDidMount () {
-    const league = defaultLeague
+    const league = currentLeague()
     return (async () => {
-      const leagues = await fetchLeagues()
       const weeks = await fetchWeeks(league)
       const week = last(weeks) || 0
       const stats = await fetchStats(week, league)
-      this.setState({leagues, league, weeks, week, stats, loading: false})
+      this.setState({weeks, week, stats, loading: false})
     })()
   }
 
-  leagueChange (event) {
-    const league = event.target.value
+  leagueChange (league) {
     return (async () => {
-      this.setState({league, loading: true})
+      this.setState({loading: true})
       const weeks = await fetchWeeks(league)
       const week = last(weeks) || 0
       const stats = await fetchStats(week, league)
@@ -71,8 +65,6 @@ class StatsProvider extends Component {
   }
 
   renderNav () {
-    const league = this.state.league
-    const leagues = [...this.state.leagues]
     const leagueChange = this.leagueChange.bind(this)
     const week = this.state.week
     const weeks = [0, ...this.state.weeks]
@@ -82,7 +74,7 @@ class StatsProvider extends Component {
 
     return (
       <TopNav>
-        <LeaguePicker league={league} leagues={leagues} onChange={leagueChange} />
+        <LeaguePicker onChange={leagueChange} />
         <GenderFilter filter={genderFilter} onChange={genderChange} />
         <WeekPicker week={week} weeks={weeks} onChange={weekChange} />
       </TopNav>

--- a/web/src/views/TeamDashboard/index.js
+++ b/web/src/views/TeamDashboard/index.js
@@ -1,11 +1,10 @@
-import _ from 'lodash'
-import ls from 'local-storage'
 import React, { Component } from 'react'
 import Container from '@material-ui/core/Container'
 import TeamPicker from './TeamPicker'
 import Table from './Table'
 import Chart from './Chart'
 import { calcSalaryLimits } from '../../helpers'
+import { map, sum, sortBy } from 'lodash'
 
 export default class TeamDashboard extends Component {
   constructor (props) {
@@ -14,7 +13,7 @@ export default class TeamDashboard extends Component {
     this.state = {
       loading: true,
       players: this.props.players,
-      team: ls.get('team') || this.props.players[0].team
+      team: this.props.players[0].team
     }
 
     this.teamChanged = this.teamChanged.bind(this)
@@ -22,16 +21,15 @@ export default class TeamDashboard extends Component {
 
   teamChanged (event) {
     const teamName = event.target.value
-    ls.set('team', teamName)
     this.setState({team: teamName})
   }
 
   render () {
     const {team, players: allPlayers } = this.state;
     const teamPlayers = allPlayers.filter(p => p.team === team);
-    const sortedPlayers = _.sortBy(teamPlayers, (p) => p.salary).reverse();
-    const salaries = _.map(sortedPlayers, (p) => p.salary);
-    const teamSalary = _.sum(salaries);
+    const sortedPlayers = sortBy(teamPlayers, (p) => p.salary).reverse();
+    const salaries = map(sortedPlayers, (p) => p.salary);
+    const teamSalary = sum(salaries);
     const { salaryCap, salaryFloor } = calcSalaryLimits(allPlayers);
     const overCap = teamSalary > salaryCap;
     const underFloor = teamSalary < salaryFloor;

--- a/web/src/views/TradeSimulator/index.js
+++ b/web/src/views/TradeSimulator/index.js
@@ -3,7 +3,6 @@ import { Grid, Container, Button } from '@material-ui/core'
 import PlayerSelect from '../../components/PlayerSelect'
 import Chart from './Chart'
 import { calcSalaryLimits } from '../../helpers'
-import { fetchPlayers } from "../../api"
 import { findIndex, sortBy, uniq, remove, isEqual, map } from 'lodash'
 
 export default class TradeSimulator extends Component {
@@ -17,13 +16,6 @@ export default class TradeSimulator extends Component {
       playerA: '',
       playerB: '',
     }
-  }
-
-  componentDidMount () {
-    (async () => {
-      const players = await fetchPlayers()
-      this.setState({players, loading: false})
-    })()
   }
 
   playerAChanged (value: string) {


### PR DESCRIPTION
This adds the league picker to the other pages in the app. UI wise I am happy with this for now. 

Code wise we might be able to re-structure the app better now - ideally we would have a clean heirarchy of components and state where right now it feels a bit scattered. The StatsPage and SalaryPage could probably be re-written with some kind of higher order data provider react pattern.