### PR TITLE
Request storage permissions on app startup

### DIFF
--- a/android/app/src/main/java/org/ocua/parity/ChooseTeams.java
+++ b/android/app/src/main/java/org/ocua/parity/ChooseTeams.java
@@ -53,7 +53,7 @@ public class ChooseTeams extends Activity {
                 if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                     new AlertDialog.Builder(context)
                             .setTitle("Storage Permissions")
-                            .setMessage("Storage is used to save game backups Stats data could be lost without this!")
+                            .setMessage("Storage is used to save game backups. Stats data could be lost without this!")
                             .setPositiveButton("Ok", new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int which) {

--- a/android/app/src/main/java/org/ocua/parity/ChooseTeams.java
+++ b/android/app/src/main/java/org/ocua/parity/ChooseTeams.java
@@ -1,11 +1,16 @@
 package org.ocua.parity;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.PermissionChecker;
 
 import org.json.JSONArray;
 
@@ -16,6 +21,7 @@ import org.ocua.parity.tasks.FetchRoster;
 public class ChooseTeams extends Activity {
     private Context context;
     private final ChooseTeams myself = this;
+    private final int permissionRequestCode = 647662;
 
     private Teams teams;
 
@@ -31,6 +37,34 @@ public class ChooseTeams extends Activity {
         super.onStart();
         teams = new Teams();
         new FetchRoster(this, myself).execute();
+
+        int result = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (result != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, permissionRequestCode);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        if (requestCode ==  permissionRequestCode) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                // happy path
+            } else {
+                if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                    new AlertDialog.Builder(context)
+                            .setTitle("Storage Permissions")
+                            .setMessage("Storage is used to save game backups Stats data could be lost without this!")
+                            .setPositiveButton("Ok", new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    dialog.dismiss();
+                                    ActivityCompat.requestPermissions(myself, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, permissionRequestCode);
+                                }
+                            })
+                            .show();
+                }
+            }
+        }
     }
 
     public void initTeams(JSONArray response) {


### PR DESCRIPTION
We need storage permissions to save game backups, and the new tablets require modern android permission requests.