### PR TITLE
add url param includePoints to games index

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -80,7 +80,9 @@ def players(league_id):
 @cache.cached()
 @app.route('/api/<league_id>/games')
 def games(league_id):
-    games = [game.to_dict() for game in Game.query.filter_by(league_id=league_id)]
+    include_points = request.args.get('includePoints') == 'true'
+    query = Game.query.filter_by(league_id=league_id)
+    games = [game.to_dict(include_points=include_points) for game in query]
     return jsonify(games)
 
 
@@ -89,7 +91,6 @@ def games(league_id):
 def game(league_id, id):
     game = Game.query.filter_by(league_id=league_id, id=id).first()
     stats = build_stats_response(league_id, [game])
-
     return jsonify({**game.to_dict(include_points=True), "stats": stats})
 
 

--- a/server/test.py
+++ b/server/test.py
@@ -113,6 +113,9 @@ class ServerTests(FlaskTest, SnapShotTest):
         response = self.client.get('/api/1/games')
         assert response.status_code == 200
 
+        response = self.client.get('/api/1/games?includePoints=true')
+        assert response.status_code == 200
+
         response = self.client.get('/api/1/games/1')
         assert response.status_code == 200
 


### PR DESCRIPTION
I added a query param `includePoints` to make it simpler to request all the raw data from the server in one request. Previously you would need to query the games endpoint to gather the IDs and then make individual requests to get all the data. The app uses this endpoint for a index page which doesn't need the additional data. The default is to not include this data for performance reasons.