### PR TITLE
Update schedule to use db ids instead of zuluru ids

### DIFF
--- a/server/models/matchup.py
+++ b/server/models/matchup.py
@@ -5,8 +5,8 @@ from .league import League
 class Matchup(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     league_id = db.Column(db.Integer, db.ForeignKey('league.id'), nullable=False)
-    home_team_id = db.Column(db.Integer, db.ForeignKey('team.zuluru_id'), nullable=False)
-    away_team_id = db.Column(db.Integer, db.ForeignKey('team.zuluru_id'), nullable=False)
+    home_team_id = db.Column(db.Integer, db.ForeignKey('team.id'), nullable=False)
+    away_team_id = db.Column(db.Integer, db.ForeignKey('team.id'), nullable=False)
     week = db.Column(db.Integer)
     game_start = db.Column(db.DateTime)
     game_end = db.Column(db.DateTime)


### PR DESCRIPTION
Now that we use our own ids, we should use those for the schedule instead of zuluru ids.