### PR TITLE
Add uses-library for legacy http client

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,10 @@
         <activity android:name=".SelectPlayers"></activity>
         <activity android:name=".Stats"></activity>
         <activity android:name=".SubmitGame"></activity>
+
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Recent versions of android require this manifest entry to use the legacy Apache HTTP client.
We should probably move away from using that at some point!