### PR TITLE
Fix table perf 2

### DIFF
--- a/web/src/components/LeaguePicker.tsx
+++ b/web/src/components/LeaguePicker.tsx
@@ -8,21 +8,16 @@ import { map } from 'lodash'
 
 const useStyles = makeStyles((theme) => ({
   selectRoot: {
-    color: props => (props as any).color,
+    color: 'white',
     fontSize: 14,
     minWidth: 80
   },
   icon: {
-    color: props => (props as any).color
+    color: 'white'
   }
 }));
 
-function LeaguePicker(
-  props: {
-    color: string,
-    onChange?: (league: string) => void
-  }
-) {
+function LeaguePicker(props: { onChange?: (league: string) => void}) {
   const classes = useStyles(props);
   const [league, setLeague] = useLeague();
 

--- a/web/src/components/StatsFilters.tsx
+++ b/web/src/components/StatsFilters.tsx
@@ -29,8 +29,8 @@ const StatsFilters = ({data, changeWeek}: any) => {
         >
           <DialogTitle>Filters</DialogTitle>
           <DialogContent className="filters">
-            <LeaguePicker color="black" onChange={() => openFilters(false)}/>
-            <WeekPicker color="black" week={week} weeks={weekOptions} onChange={(w) => { openFilters(false); changeWeek(w) }} />
+            <LeaguePicker onChange={() => openFilters(false)}/>
+            <WeekPicker week={week} weeks={weekOptions} onChange={(w) => { openFilters(false); changeWeek(w) }} />
           </DialogContent>
           <DialogActions>
             <Button onClick={() => openFilters(false)} color="primary">
@@ -43,8 +43,8 @@ const StatsFilters = ({data, changeWeek}: any) => {
   } else {
     return (
       <React.Fragment>
-        <LeaguePicker color="white"/>
-        <WeekPicker color="white" week={week} weeks={weekOptions} onChange={(w) => changeWeek(w)} />
+        <LeaguePicker/>
+        <WeekPicker week={week} weeks={weekOptions} onChange={(w) => changeWeek(w)} />
       </React.Fragment>
     )
   }

--- a/web/src/components/StatsFilters.tsx
+++ b/web/src/components/StatsFilters.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import LeaguePicker from '../components/LeaguePicker'
+import WeekPicker from '../components/WeekPicker'
+import { IconButton, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@material-ui/core'
+import FilterListIcon from '@material-ui/icons/FilterList'
+import { useMediaQuery } from 'react-responsive'
+
+const StatsFilters = ({data, changeWeek}: any) => {
+  const [filtersOpen, openFilters] = useState(false)
+
+  const isMobile = useMediaQuery({ query: '(max-device-width: 480px)' });
+
+  const week = data.week || 0
+  const weekOptions = [0, ...data.weeks] // add 0 for "all"
+
+  if (isMobile) {
+    return (
+      <React.Fragment>
+        <IconButton onClick={() => openFilters(true)}>
+          <FilterListIcon style={{color: "white"}} />
+        </IconButton>
+        <Dialog
+          disableBackdropClick
+          disableEscapeKeyDown
+          maxWidth="sm"
+          fullWidth={true}
+          open={filtersOpen}
+          onClose={() => openFilters(false)}
+        >
+          <DialogTitle>Filters</DialogTitle>
+          <DialogContent className="filters">
+            <LeaguePicker color="black" onChange={() => openFilters(false)}/>
+            <WeekPicker color="black" week={week} weeks={weekOptions} onChange={(w) => { openFilters(false); changeWeek(w) }} />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => openFilters(false)} color="primary">
+              Close
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </React.Fragment>
+    )
+  } else {
+    return (
+      <React.Fragment>
+        <LeaguePicker color="white"/>
+        <WeekPicker color="white" week={week} weeks={weekOptions} onChange={(w) => changeWeek(w)} />
+      </React.Fragment>
+    )
+  }
+}
+
+export default StatsFilters

--- a/web/src/components/WeekPicker.tsx
+++ b/web/src/components/WeekPicker.tsx
@@ -6,18 +6,17 @@ import { map } from 'lodash'
 
 const useStyles = makeStyles((theme) => ({
   selectRoot: {
-    color: props => (props as any).color,
+    color: 'white',
     fontSize: 14,
     minWidth: 80
   },
   icon: {
-    color: props => (props as any).color
+    color: 'white'
   }
 }));
 
 function WeekPicker(
   props: {
-    color: string,
     week: number;
     weeks: number[];
     onChange: (week: number) => void

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -15,7 +15,7 @@ html, body, #root {
 .filters {
   margin: auto;
 }
-.filters .MuiInputBase-inputSelect {
+.filters .MuiSelect-root {
   color: black !important;
   width: 160px;
   border: rgba(0, 0, 0, 0.87);

--- a/web/src/views/GamesList.tsx
+++ b/web/src/views/GamesList.tsx
@@ -95,7 +95,7 @@ function GamesList() {
   return (
     <React.Fragment>
       <Layout>
-        <LeaguePicker color="white"/>
+        <LeaguePicker/>
       </Layout>
       { renderMain() }
     </React.Fragment>

--- a/web/src/views/Leaderboards/index.tsx
+++ b/web/src/views/Leaderboards/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import Card from './Card'
 import { Stats } from '../../api'
 
-
 export default function Leaderboards(props: {stats: Stats}) {
   const stats = props.stats
 

--- a/web/src/views/SalaryPage.tsx
+++ b/web/src/views/SalaryPage.tsx
@@ -38,7 +38,7 @@ function SalaryProvider(props: {component: React.FunctionComponent<ISalaryPageCo
   return (
     <div>
       <Layout>
-        <LeaguePicker color="white"/>
+        <LeaguePicker/>
       </Layout>
       <Main />
     </div>

--- a/web/src/views/StatsPage.tsx
+++ b/web/src/views/StatsPage.tsx
@@ -1,11 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Layout from '../layout'
 import Loading from '../components/Loading'
-import LeaguePicker from '../components/LeaguePicker'
-import WeekPicker from '../components/WeekPicker'
-import { IconButton, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@material-ui/core'
-import FilterListIcon from '@material-ui/icons/FilterList'
-import { useMediaQuery } from 'react-responsive'
+import StatsFilters from '../components/StatsFilters'
 import { useLeague } from '../hooks/league'
 import { useStats } from '../hooks/stats'
 import { Stats } from '../api'
@@ -18,51 +14,6 @@ interface IStatsPageComponentProps {
 function StatsPage(props: {component: React.FunctionComponent<IStatsPageComponentProps>}) {
   const [league] = useLeague();
   const [data, loading, changeWeek] = useStats(league);
-
-  const [filtersOpen, openFilters] = useState(false)
-
-  const isMobile = useMediaQuery({ query: '(max-device-width: 480px)' });
-
-  const Filters = () => {
-    const week = data.week || 0
-    const weekOptions = [0, ...data.weeks] // add 0 for "all"
-
-    if (isMobile) {
-      return (
-        <React.Fragment>
-          <IconButton onClick={() => openFilters(true)}>
-            <FilterListIcon style={{color: "white"}} />
-          </IconButton>
-          <Dialog
-            disableBackdropClick
-            disableEscapeKeyDown
-            maxWidth="sm"
-            fullWidth={true}
-            open={filtersOpen}
-            onClose={() => openFilters(false)}
-          >
-            <DialogTitle>Filters</DialogTitle>
-            <DialogContent className="filters">
-              <LeaguePicker color="black" onChange={() => openFilters(false)}/>
-              <WeekPicker color="black" week={week} weeks={weekOptions} onChange={(w) => { openFilters(false); changeWeek(w) }} />
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => openFilters(false)} color="primary">
-                Close
-              </Button>
-            </DialogActions>
-          </Dialog>
-        </React.Fragment>
-      )
-    } else {
-      return (
-        <React.Fragment>
-          <LeaguePicker color="white"/>
-          <WeekPicker color="white" week={week} weeks={weekOptions} onChange={(w) => changeWeek(w)} />
-        </React.Fragment>
-      )
-    }
-  }
 
   const Main = () => {
     if (loading) return <Loading />;
@@ -77,7 +28,7 @@ function StatsPage(props: {component: React.FunctionComponent<IStatsPageComponen
   return (
     <React.Fragment>
       <Layout>
-        <Filters />
+        <StatsFilters data={data} changeWeek={changeWeek}/>
       </Layout>
       <Main />
     </React.Fragment>


### PR DESCRIPTION
redo of https://github.com/kevinhughes27/parity-server/pull/382 without touching any packages (chartjs is suuuuuper fragile...)

There was an issue with the stats table rendering performance. Opening the filter modal on mobile caused a re-render which made the problem worse. I also re-did how I fixed the styling on the filter inputs. Turns our my css overrides were broken and fixing them was the better option than adding more props.