### PR TITLE
pass league through each activity intent

### DIFF
--- a/android/app/src/main/java/org/ocua/parity/SelectPlayers.java
+++ b/android/app/src/main/java/org/ocua/parity/SelectPlayers.java
@@ -180,6 +180,7 @@ public class SelectPlayers extends Activity {
     private void editRosters() {
         Intent intent = new Intent(this, EditRosters.class);
         Bundle bundle = new Bundle();
+        bundle.putSerializable("league", league);
         bundle.putSerializable("teams", teams);
         bundle.putSerializable("bookkeeper", bookkeeper);
         bundle.putStringArrayList("leftPlayers", leftPlayers);
@@ -230,6 +231,7 @@ public class SelectPlayers extends Activity {
 
             Intent intent = new Intent(context, Stats.class);
             Bundle bundle = new Bundle();
+            bundle.putSerializable("league", league);
             bundle.putSerializable("teams", teams);
             bundle.putSerializable("bookkeeper", bookkeeper);
             bundle.putSerializable("leftPlayers", leftPlayers);
@@ -260,6 +262,7 @@ public class SelectPlayers extends Activity {
 
                             Intent intent = new Intent(context, Stats.class);
                             Bundle bundle = new Bundle();
+                            bundle.putSerializable("league", league);
                             bundle.putSerializable("teams", teams);
                             bundle.putSerializable("bookkeeper", bookkeeper);
                             bundle.putSerializable("leftPlayers", leftPlayers);

--- a/android/app/src/main/java/org/ocua/parity/Stats.java
+++ b/android/app/src/main/java/org/ocua/parity/Stats.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 
 import org.ocua.parity.customLayout.CustomLinearLayout;
+import org.ocua.parity.model.League;
 import org.ocua.parity.model.Team;
 import org.ocua.parity.model.Teams;
 
@@ -33,6 +34,7 @@ public class Stats extends Activity {
     private View.OnClickListener mainOnClickListener;
     private View.OnClickListener changeModeListener;
 
+    private League league;
     private Teams teams;
     private Bookkeeper bookkeeper;
 
@@ -60,13 +62,15 @@ public class Stats extends Activity {
     }
 
     private void loadIntent() {
-        teams = (Teams)this.getIntent().getSerializableExtra("teams");
-        bookkeeper = (Bookkeeper) this.getIntent().getSerializableExtra("bookkeeper");
+        Intent intent = this.getIntent();
+        league = (League) intent.getSerializableExtra("league");
+        teams = (Teams) intent.getSerializableExtra("teams");
+        bookkeeper = (Bookkeeper) intent.getSerializableExtra("bookkeeper");
         leftTeam = bookkeeper.homeTeam;
         rightTeam = bookkeeper.awayTeam;
 
-        leftPlayers = (ArrayList<String>)this.getIntent().getSerializableExtra("leftPlayers");
-        rightPlayers = (ArrayList<String>)this.getIntent().getSerializableExtra("rightPlayers");
+        leftPlayers = (ArrayList<String>) intent.getSerializableExtra("leftPlayers");
+        rightPlayers = (ArrayList<String>) intent.getSerializableExtra("rightPlayers");
     }
 
     private void renderGameBar() {
@@ -222,6 +226,7 @@ public class Stats extends Activity {
     private void editRosters() {
         Intent intent = new Intent(this, EditRosters.class);
         Bundle bundle = new Bundle();
+        bundle.putSerializable("league", league);
         bundle.putSerializable("teams", teams);
         bundle.putSerializable("bookkeeper", bookkeeper);
         bundle.putStringArrayList("leftPlayers", leftPlayers);
@@ -246,6 +251,7 @@ public class Stats extends Activity {
     private void selectPlayers(Boolean flipPlayers) {
         Intent intent = new Intent(context, SelectPlayers.class);
         Bundle bundle = new Bundle();
+        bundle.putSerializable("league", league);
         bundle.putSerializable("teams", teams);
         bundle.putSerializable("bookkeeper", bookkeeper);
         if (flipPlayers) {


### PR DESCRIPTION
Fixes the crash in the latest build when editing rosters. The actual java exception:

```
--------- beginning of crash
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.masse.parityleaguestats, PID: 14579
    java.lang.NullPointerException: Attempt to read from field 'int org.ocua.parity.model.League.lineSize' on a null object reference
        at org.ocua.parity.SelectPlayers.playersSelected(SelectPlayers.java:225)
        at org.ocua.parity.SelectPlayers.access$000(SelectPlayers.java:27)
        at org.ocua.parity.SelectPlayers$2.onClick(SelectPlayers.java:124)
        at android.view.View.performClick(View.java:5637)
        at android.view.View$PerformClick.run(View.java:22429)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6119)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:77
```

The cause is that we changed the league object and used it in some new activities but didn't update all the paths that lead to that activity to have the serialized league object. Basically every activity needs this full object now so it joins the list of things we serialize and pass to each activity.

Future note - testing EditRosters initially is only one case. It is also worth testing EditRosters "mid game" since this properly tests the full activity chain.