### PR TITLE
add game delete admin endpoint and add to editor front end

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
-  "proxy": "https://parity.ocua.ca",
+  "proxy": "http://127.0.0.1:5000",
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
     "@emotion/react": "^11.7.0",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -107,6 +107,21 @@ const saveGame = async (gameId: string, leagueId: string, json: string, password
   })
 }
 
+const deleteGame = async (gameId: string, leagueId: string, password: string|null) => {
+  const url = `/api/${leagueId}/games/${gameId}`
+
+  // clear cache
+  delete dataCache[url]
+
+  return fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `${password}`
+    },
+  })
+}
+
 export interface Player {
   name: string;
   team: string;
@@ -165,5 +180,6 @@ export {
   fetchPlayers,
   fetchWeeks,
   fetchStats,
-  saveGame
+  saveGame,
+  deleteGame,
 }

--- a/web/src/views/Game/Editor.tsx
+++ b/web/src/views/Game/Editor.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import Points from './Points'
 import Button from '@mui/material/Button'
 import CodeMirror from '@uiw/react-codemirror'
 import { json as jsonLang } from '@codemirror/lang-json'
-import { saveGame, Game } from '../../api'
+import { saveGame, deleteGame, Game } from '../../api'
 
 
 export default function GameEditor(props: {gameId: string, leagueId: string, game: Game}) {
@@ -30,6 +31,8 @@ export default function GameEditor(props: {gameId: string, leagueId: string, gam
   const [json, setJson] = React.useState(JSON.stringify(fields, null, 2))
   const [previewing, setPreviewing] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const navigate = useNavigate()
 
   const Preview = () => {
     try {
@@ -69,20 +72,43 @@ export default function GameEditor(props: {gameId: string, leagueId: string, gam
       />
       { previewing ? <Preview/> : null }
       <Button
-        style={{position: 'fixed', top: 10, right: 90, background: 'white'}}
+        style={{position: 'fixed', top: 10, right: 175, background: 'white'}}
         onClick={() => { setPreviewing(!previewing) }}
       >
         { previewing ? 'Close Preview' : 'Open Preview' }
       </Button>
+
+      <Button
+        disabled={deleting}
+        style={{position: 'fixed', top: 10, right: 90, background: 'yellow'}}
+        onClick={async () => {
+          setDeleting(true)
+          const password = prompt('Please enter password')
+          const response = await deleteGame(props.gameId, props.leagueId, password)
+
+          if (response.status === 200) {
+            console.log(`[Success] ${props.gameId} deleted.`)
+            navigate("/games/")
+          } else {
+            const text = await response.text()
+            console.log(text)
+            setSaving(false)
+          }
+        }}
+      >
+        { deleting ? 'Deleting' : 'Delete' }
+      </Button>
+
       <Button
         disabled={saving}
-        style={{position: 'fixed', top: 10, right: 10, background: 'white'}}
+        style={{position: 'fixed', top: 10, right: 10, background: 'yellow'}}
         onClick={async () => {
           setSaving(true)
           const password = prompt('Please enter password')
           const response = await saveGame(props.gameId, props.leagueId, json, password)
+
           if (response.status === 200) {
-            console.log("Success")
+            console.log(`[Success] ${props.gameId} updated.`)
             setSaving(false)
           } else {
             const text = await response.text()


### PR DESCRIPTION
This PR adds a delete button to the game editor that requires the admin password the same as the edit function. This allows the league coordinator to self serve game delete requests for duplicate submissions. The logic is the same as the cli method that can also be used (it supports deleting multiple games though while the api does not).

![image](https://github.com/kevinhughes27/parity-server/assets/1965489/92541c77-351e-4072-9204-d763037cd97c)
