### PR TITLE
Moved backups to app-specific external storage

### DIFF
--- a/android/app/src/main/java/org/ocua/parity/Bookkeeper.java
+++ b/android/app/src/main/java/org/ocua/parity/Bookkeeper.java
@@ -51,9 +51,12 @@ public class Bookkeeper implements Serializable {
     private HashSet<String> homeParticipants;
     private HashSet<String> awayParticipants;
 
-    public void startGame(League league, int week, Team leftTeam, Team rightTeam) {
+    private File pathToExternalStorage;
+
+    public void startGame(League league, int week, Team leftTeam, Team rightTeam, File pathToExternalStorage) {
         this.league = league;
         this.week = week;
+        this.pathToExternalStorage = pathToExternalStorage;
         activeGame = new Game();
         homeTeam = leftTeam;
         awayTeam = rightTeam;
@@ -327,8 +330,7 @@ public class Bookkeeper implements Serializable {
                         String gameName = homeTeam.name + "-" + awayTeam.name;
                         String fileName = timestamp + "_" + gameName + ".json";
 
-                        File pathToExternalStorage = Environment.getExternalStorageDirectory();
-                        File backupDirectory = new File(pathToExternalStorage, "ParityLeagueStats" + File.separator + "autosave" + File.separator + datestamp);
+                        File backupDirectory = new File(pathToExternalStorage, "autosave" + File.separator + datestamp);
 
                         backupDirectory.mkdirs();
 

--- a/android/app/src/main/java/org/ocua/parity/ChooseTeams.java
+++ b/android/app/src/main/java/org/ocua/parity/ChooseTeams.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.Environment;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -15,6 +16,7 @@ import org.ocua.parity.model.Team;
 import org.ocua.parity.model.Teams;
 import org.ocua.parity.tasks.LoadSchedule;
 
+import java.io.File;
 import java.util.ArrayList;
 
 public class ChooseTeams extends Activity {
@@ -122,8 +124,9 @@ public class ChooseTeams extends Activity {
         bundle.putSerializable("league", league);
         bundle.putSerializable("teams", teams);
 
+        File pathToExternalStorage = this.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS);
         Bookkeeper bookkeeper = new Bookkeeper();
-        bookkeeper.startGame(league, week, homeTeam, awayTeam);
+        bookkeeper.startGame(league, week, homeTeam, awayTeam, pathToExternalStorage);
         bundle.putSerializable("bookkeeper", bookkeeper);
 
         intent.putExtras(bundle);

--- a/android/app/src/main/java/org/ocua/parity/tasks/UploadGame.java
+++ b/android/app/src/main/java/org/ocua/parity/tasks/UploadGame.java
@@ -74,8 +74,8 @@ public class UploadGame extends AsyncTask<String, String, String> {
 
     private void saveBackup(String json) {
         try {
-            File pathToExternalStorage = Environment.getExternalStorageDirectory();
-            File backupDirectory = new File(pathToExternalStorage, "ParityLeagueStats");
+            File pathToExternalStorage = this.parent.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS);
+            File backupDirectory = new File(pathToExternalStorage, "CompletedGames");
 
             String timestamp = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
 

--- a/android/app/src/test/java/org/ocua/parity/BookkeeperTest.java
+++ b/android/app/src/test/java/org/ocua/parity/BookkeeperTest.java
@@ -3,6 +3,7 @@ package org.ocua.parity;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.List;
 
 import org.ocua.parity.model.Event;
@@ -32,7 +33,7 @@ public class BookkeeperTest {
         away = new Team("Team B", 2);
         league = new League();
         bookkeeper = new Bookkeeper();
-        bookkeeper.startGame(league, week, home, away);
+        bookkeeper.startGame(league, week, home, away, new File("."));
     }
 
     @Test


### PR DESCRIPTION
Backups weren't working on the newer tablet because Android started restricting app from accessing external storage. Instead apps now get their own external storage directories.