### PR TITLE
sort players open first then non open second in the stat keeper

### DIFF
--- a/web/src/views/StatKeeper/EditRosters.tsx
+++ b/web/src/views/StatKeeper/EditRosters.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Bookkeeper } from './bookkeeper';
+import { Bookkeeper, sortRosters } from './bookkeeper';
 import { useTeams } from './hooks';
 import EditRoster from './EditRoster';
 import { StoredPlayer } from './db';
@@ -17,11 +17,11 @@ const EditRosters: React.FC<{ bookkeeper: Bookkeeper }> = ({ bookkeeper }) => {
   const [awayRoster, setAwayRoster] = useState<StoredPlayer[]>([]);
 
   const sortAndSetHomeRoster = (roster: StoredPlayer[]) => {
-    setHomeRoster([...roster].sort((a, b) => a.name.localeCompare(b.name)));
+    setHomeRoster(sortRosters(roster));
   };
 
   const sortAndSetAwayRoster = (roster: StoredPlayer[]) => {
-    setAwayRoster([...roster].sort((a, b) => a.name.localeCompare(b.name)));
+    setAwayRoster(sortRosters(roster));
   };
 
   useEffect(() => {

--- a/web/src/views/StatKeeper/bookkeeper.ts
+++ b/web/src/views/StatKeeper/bookkeeper.ts
@@ -9,6 +9,18 @@ import {
 import { type GameView } from './db';
 import { EventType, GameMethods, GameState, PointMethods } from './gameLogic';
 
+// Helper function to sort players by gender (open first) then alphabetically
+export function sortRosters(players: StoredPlayer[]): StoredPlayer[] {
+  return [...players].sort((a, b) => {
+    // First sort by gender (open first)
+    if (a.is_open !== b.is_open) {
+      return a.is_open ? -1 : 1;
+    }
+    // Then sort alphabetically
+    return a.name.localeCompare(b.name);
+  });
+}
+
 interface UploadedGamePayload {
   league_id: number;
   week: number;
@@ -670,11 +682,11 @@ export class Bookkeeper {
   }
 
   getHomeRoster(): StoredPlayer[] {
-    return [...this.game.homeRoster].sort((a, b) => a.name.localeCompare(b.name));
+    return sortRosters(this.game.homeRoster);
   }
 
   getAwayRoster(): StoredPlayer[] {
-    return [...this.game.awayRoster].sort((a, b) => a.name.localeCompare(b.name));
+    return sortRosters(this.game.awayRoster);
   }
 
   // Team information accessors


### PR DESCRIPTION
I was worried this would break the tests more but the order of the players in the test variables already doesn't match the order they get displayed in the stat keeper (which is good) so no changes were required. I added some extra logic to be super sure all the warnings are working properly.

<img width="1900" height="1716" alt="image" src="https://github.com/user-attachments/assets/ac13313a-3a56-4a14-a630-45b04cc75d8e" />
